### PR TITLE
Replace Rails app with Budget Quest (static + Firebase sync)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy Budget Quest to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - claude/budget-tracker-app-6fWbQ
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - claude/budget-tracker-app-6fWbQ
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 💰 Budget Quest
 
-A fun, neon-themed budget tracker. No backend, no signup — just open `index.html` in a browser.
+A fun, neon-themed budget tracker. Open `index.html` in a browser — no backend required.
+Optional Firebase sync lets you and your partner share the same budget across devices in real time.
 
 ## Features
 
@@ -11,26 +12,111 @@ A fun, neon-themed budget tracker. No backend, no signup — just open `index.ht
 - **Monthly reset** — start a new month and your categories carry over with $0 spent.
 - **History** — flip back through previous months as read-only snapshots.
 - **Custom icons & colors** per category.
-- **Animated particle background** + glassmorphism + shimmer + shake effects.
-- All data stored locally in `localStorage`. Your numbers never leave your machine.
+- **Cross-device household sync** (optional, via Firebase).
+- All data stored in your browser's `localStorage`. With sync on, also mirrored to Firestore.
 
-## Run it
+## Run it locally
 
-Just open `index.html` in any modern browser. That's it.
+Because the app uses ES modules, you have to serve it (don't double-click — `file://` blocks modules).
 
 ```bash
-# macOS
-open index.html
-
-# Linux
-xdg-open index.html
-
-# Or serve locally with any static server
 python3 -m http.server 8000
+# then open http://localhost:8000
 ```
 
 ## Files
 
 - `index.html` — markup
 - `styles.css` — theme & animations
-- `app.js` — state, rendering, effects (vanilla JS, no dependencies)
+- `app.js` — state, rendering, effects
+- `sync.js` — optional Firebase Firestore sync layer
+- `firebase-config.js` — your Firebase project config (placeholders by default)
+
+---
+
+## 🤝 Setting up household sync (optional, ~10 min)
+
+This lets you and your partner share the same budget across phones, laptops, browsers — anything.
+Updates show up on the other device in real time.
+
+### 1. Create a Firebase project
+
+1. Go to **https://console.firebase.google.com**
+2. Click **Add project** → name it anything (e.g. "budget-quest") → continue
+3. You can skip Google Analytics
+
+### 2. Add a Web app
+
+1. In the project dashboard, click the **`</>`** (Web) icon
+2. Give it a nickname → **Register app**
+3. Copy the `firebaseConfig` object that's shown — you'll paste this in step 4
+4. Skip the SDK scripts step — Budget Quest already includes them
+
+### 3. Enable services
+
+1. **Authentication** → Get started → **Sign-in method** tab → enable **Anonymous**
+2. **Firestore Database** → Create database → choose any location → start in **production mode**
+3. Once Firestore is created, go to its **Rules** tab and replace the rules with:
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /households/{householdId} {
+      allow read, write: if request.auth != null
+        && householdId.size() >= 6
+        && householdId.size() <= 50;
+    }
+  }
+}
+```
+
+Click **Publish**.
+
+### 4. Authorize your domain
+
+1. **Authentication** → **Settings** → **Authorized domains**
+2. Add your GitHub Pages domain (e.g. `coghillb.github.io`)
+3. `localhost` is already authorized for local testing
+
+### 5. Drop your config into the app
+
+Open `firebase-config.js` in this repo and paste the values from step 2:
+
+```js
+export const firebaseConfig = {
+  apiKey: "AIzaSy…",
+  authDomain: "budget-quest-xxxx.firebaseapp.com",
+  projectId: "budget-quest-xxxx",
+  storageBucket: "budget-quest-xxxx.appspot.com",
+  messagingSenderId: "123…",
+  appId: "1:123…:web:abc…"
+};
+```
+
+These values are **not secrets** — Firebase web configs are public by design. Security comes from
+the Firestore rules and authorized domains, not from hiding the keys.
+
+Commit and push. The next time GitHub Pages redeploys, sync goes live.
+
+### 6. Use it
+
+1. Open the app — it'll prompt you to **Create new** or **Join existing** household.
+2. Pick a friendly code like `mint-tiger-7`. Share it with your partner.
+3. They open the app on their device and **Join existing** with the same code.
+4. You're both editing the same budget. Add an expense on your phone, watch it appear on their laptop a second later.
+
+The little **🔗 Synced** badge in the top bar shows connection status. Click it to see/copy your code, change household, or disconnect.
+
+### Troubleshooting
+
+- **"Sync error"** → check the browser console. Most often: domain not authorized, or rules not published.
+- **Wife sees old data** → make sure she's joined the same code as you (case-insensitive).
+- **I want to start over** → click 🔗 in the header → Disconnect, then re-create with a new code.
+
+---
+
+## Privacy
+
+- **Without sync**: data lives only in your browser's `localStorage`. Nothing leaves your machine.
+- **With sync**: data also lives in your private Firestore database. Anyone with your household code (and access to a browser pointed at your authorized domain) can read/edit. So pick a code that's not guessable.

--- a/app.js
+++ b/app.js
@@ -365,7 +365,7 @@ import { firebaseConfig } from './firebase-config.js';
     m.income.push({ id: uid(), name, amount: +amount });
     save();
     render();
-    fireConfetti(['#2bd99f', '#5cffb1', '#00e0ff']);
+    fireConfetti(['#10b981', '#34d399', '#06b6d4']);
     toast(`+${fmt(amount)} income added 💸`, 'success');
   }
 
@@ -644,7 +644,7 @@ import { firebaseConfig } from './firebase-config.js';
 
   // ---------- Effects ----------
   function fireConfetti(palette) {
-    const colors = palette || ['#7c5cff', '#00e0ff', '#ff5cf3', '#2bd99f', '#ffb648'];
+    const colors = palette || ['#6366f1', '#f43f5e', '#10b981', '#f59e0b', '#06b6d4'];
     const layer = document.getElementById('confetti-layer');
     const count = 60;
     for (let i = 0; i < count; i++) {
@@ -676,66 +676,6 @@ import { firebaseConfig } from './firebase-config.js';
     t.textContent = message;
     c.appendChild(t);
     setTimeout(() => t.remove(), 3200);
-  }
-
-  // ---------- Particle background ----------
-  function initBackground() {
-    const canvas = document.getElementById('bg-canvas');
-    const ctx = canvas.getContext('2d');
-    let w, h;
-    const dots = [];
-    const COUNT = 40;
-
-    function resize() {
-      w = canvas.width = window.innerWidth * window.devicePixelRatio;
-      h = canvas.height = window.innerHeight * window.devicePixelRatio;
-    }
-    window.addEventListener('resize', resize);
-    resize();
-
-    for (let i = 0; i < COUNT; i++) {
-      dots.push({
-        x: Math.random() * w,
-        y: Math.random() * h,
-        vx: (Math.random() - 0.5) * 0.3 * window.devicePixelRatio,
-        vy: (Math.random() - 0.5) * 0.3 * window.devicePixelRatio,
-        r: (1 + Math.random() * 2) * window.devicePixelRatio,
-        c: Math.random() > 0.5 ? 'rgba(124, 92, 255, 0.55)' : 'rgba(0, 224, 255, 0.45)'
-      });
-    }
-
-    function tick() {
-      ctx.clearRect(0, 0, w, h);
-      // connections
-      for (let i = 0; i < dots.length; i++) {
-        for (let j = i + 1; j < dots.length; j++) {
-          const a = dots[i], b = dots[j];
-          const dx = a.x - b.x, dy = a.y - b.y;
-          const d = Math.sqrt(dx * dx + dy * dy);
-          const max = 140 * window.devicePixelRatio;
-          if (d < max) {
-            ctx.strokeStyle = `rgba(124, 92, 255, ${0.18 * (1 - d / max)})`;
-            ctx.lineWidth = 1 * window.devicePixelRatio;
-            ctx.beginPath();
-            ctx.moveTo(a.x, a.y);
-            ctx.lineTo(b.x, b.y);
-            ctx.stroke();
-          }
-        }
-      }
-      // dots
-      for (const d of dots) {
-        d.x += d.vx; d.y += d.vy;
-        if (d.x < 0 || d.x > w) d.vx *= -1;
-        if (d.y < 0 || d.y > h) d.vy *= -1;
-        ctx.beginPath();
-        ctx.arc(d.x, d.y, d.r, 0, Math.PI * 2);
-        ctx.fillStyle = d.c;
-        ctx.fill();
-      }
-      requestAnimationFrame(tick);
-    }
-    tick();
   }
 
   // ---------- Sync ----------
@@ -1048,7 +988,6 @@ import { firebaseConfig } from './firebase-config.js';
   // ---------- Boot ----------
   function boot() {
     bindEvents();
-    initBackground();
     render();
     setSyncStatus('local');
     startSync();

--- a/app.js
+++ b/app.js
@@ -1,11 +1,19 @@
 /* ===========================================================
    Budget Quest — vanilla JS, localStorage-backed budget tracker
+   with optional Firebase sync for cross-device household sharing.
    =========================================================== */
+
+import * as sync from './sync.js';
+import { firebaseConfig } from './firebase-config.js';
 
 (() => {
   'use strict';
 
   const STORAGE_KEY = 'budget-quest:v1';
+  const HOUSEHOLD_KEY = 'budget-quest:household';
+
+  const HH_ADJ = ['mint', 'cobalt', 'crimson', 'amber', 'lilac', 'jade', 'frost', 'velvet', 'neon', 'solar', 'plum', 'coral', 'opal', 'rose', 'sage'];
+  const HH_NOUN = ['fox', 'tiger', 'otter', 'finch', 'orca', 'lynx', 'wren', 'koi', 'badger', 'falcon', 'panda', 'moth', 'crane', 'sloth', 'puma'];
 
   const EMOJI_OPTIONS = ['🛒', '🍔', '🏠', '🚗', '🎮', '✈️', '👕', '💊', '📚', '💡', '🎬', '☕', '🐕', '🎁', '💼', '🏋️', '✂️', '🎵', '🍷', '📱'];
   const COLOR_OPTIONS = ['#7c5cff', '#00e0ff', '#ff5cf3', '#2bd99f', '#ffb648', '#ff4d6d', '#ff7a3c', '#5cffb1', '#5c8aff', '#c95cff'];
@@ -33,6 +41,8 @@
   let activeSubCategoryId = null;     // for sub-budget modal
   let viewingMonth = null;            // when viewing historical (read-only)
   let confirmAction = null;
+  let syncState = 'local';            // local | connecting | synced | syncing | offline | error
+  let suspendPush = false;            // true while applying a remote update
 
   // ---------- Storage ----------
   function load() {
@@ -53,6 +63,9 @@
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     } catch (e) { console.warn('Failed to save', e); }
+    if (!suspendPush && sync.getCurrentCode()) {
+      sync.pushLocal(data);
+    }
   }
 
   // ---------- Helpers ----------
@@ -725,6 +738,162 @@
     tick();
   }
 
+  // ---------- Sync ----------
+  function generateHouseholdCode() {
+    const a = HH_ADJ[Math.floor(Math.random() * HH_ADJ.length)];
+    const n = HH_NOUN[Math.floor(Math.random() * HH_NOUN.length)];
+    const num = Math.floor(Math.random() * 90 + 10);
+    return `${a}-${n}-${num}`;
+  }
+
+  function setSyncStatus(s) {
+    syncState = s;
+    const el = document.getElementById('sync-indicator');
+    if (!el) return;
+    el.classList.remove('local', 'connecting', 'syncing', 'synced', 'offline', 'error');
+    el.classList.add(s);
+    const labels = {
+      local: 'Local',
+      connecting: 'Connecting…',
+      syncing: 'Syncing…',
+      synced: 'Synced',
+      offline: 'Offline',
+      error: 'Sync error'
+    };
+    el.querySelector('.sync-label').textContent = labels[s] || s;
+    const code = sync.getCurrentCode();
+    el.title = code ? `Household: ${code}` : 'Set up household sync';
+  }
+
+  async function startSync() {
+    if (!sync.isConfigured(firebaseConfig)) {
+      setSyncStatus('local');
+      return;
+    }
+    try {
+      await sync.init(firebaseConfig);
+      sync.onStatus(setSyncStatus);
+      const savedCode = localStorage.getItem(HOUSEHOLD_KEY);
+      if (savedCode && sync.isValidCode(savedCode)) {
+        await joinHousehold(savedCode, /* silent */ true);
+      } else {
+        // First run: prompt for household
+        openHouseholdModal();
+      }
+    } catch (e) {
+      console.warn('Sync init failed', e);
+      setSyncStatus('error');
+      toast('Could not start sync. Working offline.', 'error');
+    }
+  }
+
+  async function joinHousehold(code, silent = false) {
+    code = (code || '').trim().toLowerCase();
+    if (!sync.isValidCode(code)) {
+      toast('Code must be 6+ characters (letters, numbers, dashes).', 'error');
+      return false;
+    }
+    setSyncStatus('connecting');
+    try {
+      const remote = await sync.joinHousehold(code, applyRemote);
+      localStorage.setItem(HOUSEHOLD_KEY, code);
+      if (remote) {
+        suspendPush = true;
+        data = remote;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+        suspendPush = false;
+        render();
+        if (!silent) toast(`Joined household "${code}" 🤝`, 'success');
+      } else {
+        // New / empty household — push local state to seed it
+        sync.pushLocal(data);
+        if (!silent) toast(`Household "${code}" created. Share the code!`, 'success');
+      }
+      setSyncStatus('synced');
+      return true;
+    } catch (e) {
+      console.warn('joinHousehold failed', e);
+      setSyncStatus('error');
+      toast('Could not join household. Try again.', 'error');
+      return false;
+    }
+  }
+
+  function applyRemote(remoteData) {
+    if (!remoteData) return;
+    suspendPush = true;
+    data = remoteData;
+    if (viewingMonth && !data.months[viewingMonth]) viewingMonth = null;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    suspendPush = false;
+    render();
+    toast('Updated from your household 🔄', 'info');
+  }
+
+  function disconnectSync() {
+    sync.disconnect();
+    localStorage.removeItem(HOUSEHOLD_KEY);
+    setSyncStatus('local');
+    toast('Disconnected. Using local-only mode.', 'info');
+  }
+
+  // ---------- Household & sync modals ----------
+  function openHouseholdModal() {
+    if (!sync.isConfigured(firebaseConfig)) {
+      toast('Sync isn\'t set up. See README for Firebase steps.', 'info');
+      return;
+    }
+    const modal = document.getElementById('household-modal');
+    // Reset to "Create" tab
+    modal.querySelectorAll('.hh-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === 'create'));
+    modal.querySelectorAll('.hh-pane').forEach(p => p.hidden = p.dataset.pane !== 'create');
+    document.getElementById('hh-suggested-code').textContent = generateHouseholdCode();
+    document.getElementById('hh-join-code').value = '';
+    modal.hidden = false;
+  }
+
+  function openSyncModal() {
+    if (!sync.isConfigured(firebaseConfig)) {
+      // Bring up the setup pointer
+      const body = document.getElementById('sync-status-body');
+      body.innerHTML = `
+        <p class="muted">Sync isn't configured yet. Open <code>firebase-config.js</code> and follow the steps in <code>README.md</code>.</p>
+      `;
+      document.getElementById('sync-disconnect-btn').style.display = 'none';
+      document.getElementById('sync-change-btn').style.display = 'none';
+      document.getElementById('sync-modal').hidden = false;
+      return;
+    }
+    const code = sync.getCurrentCode();
+    const body = document.getElementById('sync-status-body');
+    if (code) {
+      body.innerHTML = `
+        <div class="sync-status-row">
+          <span class="label">Status</span>
+          <span class="value" id="sync-status-text">${syncState}</span>
+        </div>
+        <div class="sync-status-row">
+          <span class="label">Household</span>
+          <span class="value"><code id="sync-current-code">${code}</code></span>
+        </div>
+        <div class="sync-status-row">
+          <button type="button" class="ghost-btn" id="sync-copy-btn" style="width:100%;">📋 Copy code to share</button>
+        </div>
+      `;
+      document.getElementById('sync-disconnect-btn').style.display = '';
+      document.getElementById('sync-change-btn').style.display = '';
+      document.getElementById('sync-copy-btn').addEventListener('click', () => {
+        navigator.clipboard.writeText(code).then(() => toast('Code copied 📋', 'success'));
+      });
+    } else {
+      body.innerHTML = `<p class="muted">Not connected to a household yet.</p>`;
+      document.getElementById('sync-disconnect-btn').style.display = 'none';
+      document.getElementById('sync-change-btn').textContent = 'Set up sync';
+      document.getElementById('sync-change-btn').style.display = '';
+    }
+    document.getElementById('sync-modal').hidden = false;
+  }
+
   // ---------- Wire up events ----------
   function bindEvents() {
     // Month switcher
@@ -818,6 +987,62 @@
       confirmAction = null;
       closeAllModals();
     });
+
+    // Sync indicator click
+    document.getElementById('sync-indicator').addEventListener('click', openSyncModal);
+
+    // Household modal: tab switch
+    document.querySelectorAll('#household-modal .hh-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        const target = tab.dataset.tab;
+        document.querySelectorAll('#household-modal .hh-tab').forEach(t => t.classList.toggle('active', t === tab));
+        document.querySelectorAll('#household-modal .hh-pane').forEach(p => p.hidden = p.dataset.pane !== target);
+      });
+    });
+
+    // Household modal: regen code
+    document.getElementById('hh-regen').addEventListener('click', () => {
+      document.getElementById('hh-suggested-code').textContent = generateHouseholdCode();
+    });
+
+    // Household modal: copy code
+    document.getElementById('hh-copy').addEventListener('click', () => {
+      const code = document.getElementById('hh-suggested-code').textContent;
+      navigator.clipboard.writeText(code).then(() => toast('Code copied 📋', 'success'));
+    });
+
+    // Household modal: create
+    document.getElementById('hh-create-btn').addEventListener('click', async () => {
+      const code = document.getElementById('hh-suggested-code').textContent;
+      const ok = await joinHousehold(code);
+      if (ok) closeAllModals();
+    });
+
+    // Household modal: join
+    document.getElementById('hh-join-btn').addEventListener('click', async () => {
+      const code = document.getElementById('hh-join-code').value;
+      const ok = await joinHousehold(code);
+      if (ok) closeAllModals();
+    });
+    document.getElementById('hh-join-code').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') document.getElementById('hh-join-btn').click();
+    });
+
+    // Household modal: skip
+    document.getElementById('hh-skip').addEventListener('click', () => {
+      setSyncStatus('local');
+      closeAllModals();
+    });
+
+    // Sync modal actions
+    document.getElementById('sync-disconnect-btn').addEventListener('click', () => {
+      closeAllModals();
+      confirmDelete('Disconnect from household?', 'Your local data stays. You can rejoin any time.', disconnectSync);
+    });
+    document.getElementById('sync-change-btn').addEventListener('click', () => {
+      closeAllModals();
+      openHouseholdModal();
+    });
   }
 
   // ---------- Boot ----------
@@ -825,6 +1050,8 @@
     bindEvents();
     initBackground();
     render();
+    setSyncStatus('local');
+    startSync();
   }
 
   if (document.readyState === 'loading') {

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,24 @@
+// Firebase configuration.
+//
+// 1. Create a free Firebase project at https://console.firebase.google.com
+// 2. Add a Web app to the project (the </> icon).
+// 3. Copy the values from the snippet they show you into the object below.
+// 4. In the Firebase console:
+//    - Authentication -> Sign-in method -> enable "Anonymous"
+//    - Firestore Database -> Create database (in production mode)
+//    - Firestore Database -> Rules: paste the rules from README.md
+//    - Authentication -> Settings -> Authorized domains -> add your GitHub Pages
+//      domain (e.g. coghillb.github.io)
+// 5. Commit & push. Sync goes live as soon as the placeholders below are gone.
+//
+// These values are NOT secret. Firebase web configs are public by design — security
+// comes from the Firestore rules and authorized domains, not from hiding the keys.
+
+export const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_PROJECT.appspot.com",
+  messagingSenderId: "YOUR_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <canvas id="bg-canvas" aria-hidden="true"></canvas>
   <div id="confetti-layer" aria-hidden="true"></div>
 
   <header class="topbar">

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
       <button id="next-month" class="icon-btn" title="Next month">›</button>
       <button id="reset-month" class="ghost-btn" title="Start a new month">↻ New Month</button>
       <button id="history-btn" class="ghost-btn" title="View previous months">📜 History</button>
+      <button id="sync-indicator" class="sync-indicator local" title="Sync settings">
+        <span class="sync-dot"></span>
+        <span class="sync-label">Local</span>
+      </button>
     </div>
   </header>
 
@@ -215,9 +219,65 @@
     </div>
   </div>
 
+  <!-- Modal: Household sync (first-run + change household) -->
+  <div class="modal" id="household-modal" hidden>
+    <div class="modal-backdrop" data-close></div>
+    <div class="modal-card">
+      <button class="modal-close" data-close>×</button>
+      <h3>👥 Sync with your household</h3>
+      <p class="muted">Share a code with your partner so the same budget shows up on both your devices, in real time.</p>
+
+      <div class="hh-tabs">
+        <button class="hh-tab active" data-tab="create" type="button">Create new</button>
+        <button class="hh-tab" data-tab="join" type="button">Join existing</button>
+      </div>
+
+      <div class="hh-pane" data-pane="create">
+        <label>
+          Your household code
+          <div class="hh-code-display">
+            <code id="hh-suggested-code">—</code>
+            <button type="button" id="hh-regen" class="icon-btn" title="Regenerate">↻</button>
+            <button type="button" id="hh-copy" class="ghost-btn">Copy</button>
+          </div>
+          <small class="muted">Share this with your partner — they'll enter it on their device to join.</small>
+        </label>
+        <button type="button" id="hh-create-btn" class="primary-btn">Create &amp; Sync</button>
+      </div>
+
+      <div class="hh-pane" data-pane="join" hidden>
+        <label>
+          Household code
+          <input type="text" id="hh-join-code" placeholder="e.g. mint-tiger-7" autocomplete="off" />
+        </label>
+        <button type="button" id="hh-join-btn" class="primary-btn">Join &amp; Sync</button>
+      </div>
+
+      <div class="modal-actions">
+        <button type="button" class="ghost-btn" id="hh-skip">Use locally only</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: Sync status / change household -->
+  <div class="modal" id="sync-modal" hidden>
+    <div class="modal-backdrop" data-close></div>
+    <div class="modal-card">
+      <button class="modal-close" data-close>×</button>
+      <h3>🔗 Sync</h3>
+      <div id="sync-status-body">
+        <!-- Populated by app.js -->
+      </div>
+      <div class="modal-actions">
+        <button type="button" class="ghost-btn" id="sync-disconnect-btn">Disconnect (use locally)</button>
+        <button type="button" class="primary-btn" id="sync-change-btn">Change household</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Toast container -->
   <div id="toast-container" aria-live="polite"></div>
 
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -25,25 +25,47 @@
 
 * { box-sizing: border-box; }
 
+html {
+  /* Solid base color so overscroll / rubber-band never shows white. */
+  background-color: var(--bg-0);
+}
+
 html, body {
   margin: 0;
   padding: 0;
-  min-height: 100%;
+  min-height: 100vh;
   font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   color: var(--ink);
+  overflow-x: hidden;
+  overscroll-behavior: none;
+}
+
+body {
+  /* Fallback in case the fixed gradient layer fails to paint. */
+  background-color: var(--bg-0);
+}
+
+/* Fixed gradient layer — using a dedicated pseudo-element instead of
+   `background-attachment: fixed` on body avoids the per-scroll repaint
+   that caused a white flash at the bottom on slower frames. */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
   background: radial-gradient(1200px 800px at 80% -10%, #2a0e6e 0%, transparent 60%),
               radial-gradient(1000px 700px at -10% 110%, #003d66 0%, transparent 55%),
               linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 50%, var(--bg-2) 100%);
-  background-attachment: fixed;
-  overflow-x: hidden;
 }
 
-body::before {
+/* Scanline overlay (was previously on body::before). */
+body::after {
   content: '';
-  position: fixed; inset: 0;
+  position: fixed;
+  inset: 0;
   pointer-events: none;
-  background:
-    repeating-linear-gradient(0deg, rgba(255,255,255,0.02) 0 1px, transparent 1px 3px);
+  background: repeating-linear-gradient(0deg, rgba(255,255,255,0.02) 0 1px, transparent 1px 3px);
   mix-blend-mode: overlay;
   opacity: 0.35;
   z-index: 0;

--- a/styles.css
+++ b/styles.css
@@ -823,6 +823,112 @@ main {
   }
 }
 
+/* ---------- Sync indicator ---------- */
+.sync-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--glass);
+  color: var(--ink-dim);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.sync-indicator:hover { background: var(--glass-strong); color: var(--ink); }
+.sync-indicator .sync-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+  box-shadow: 0 0 0 0 currentColor;
+}
+.sync-indicator.synced     .sync-dot { background: var(--good); animation: pulse-dot 2.4s ease-in-out infinite; }
+.sync-indicator.syncing    .sync-dot { background: var(--accent-2); animation: pulse-dot 0.9s ease-in-out infinite; }
+.sync-indicator.connecting .sync-dot { background: var(--warn); animation: pulse-dot 1.2s ease-in-out infinite; }
+.sync-indicator.offline    .sync-dot { background: var(--muted); }
+.sync-indicator.error      .sync-dot { background: var(--bad); animation: pulse-dot 0.7s ease-in-out infinite; }
+.sync-indicator.local      .sync-dot { background: var(--muted); }
+
+@keyframes pulse-dot {
+  0%, 100% { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
+  50% { box-shadow: 0 0 0 4px transparent; opacity: 0.6; }
+}
+
+/* ---------- Household modal ---------- */
+.hh-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: rgba(255,255,255,0.04);
+  border-radius: 12px;
+  margin-bottom: 18px;
+}
+.hh-tab {
+  flex: 1;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--ink-dim);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.hh-tab:hover { color: var(--ink); }
+.hh-tab.active {
+  background: linear-gradient(135deg, var(--accent), var(--accent-3));
+  color: #fff;
+  box-shadow: 0 2px 12px rgba(124, 92, 255, 0.4);
+}
+
+.hh-code-display {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  padding: 12px 14px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+}
+.hh-code-display code {
+  flex: 1;
+  font-family: 'SF Mono', 'Monaco', Consolas, monospace;
+  font-size: 16px;
+  letter-spacing: 1px;
+  color: var(--accent-2);
+  font-weight: 600;
+}
+.hh-code-display .icon-btn { width: 32px; height: 32px; font-size: 16px; }
+.hh-code-display .ghost-btn { padding: 6px 12px; font-size: 12px; }
+
+#hh-create-btn, #hh-join-btn { width: 100%; margin-top: 8px; }
+
+.sync-status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 14px;
+}
+.sync-status-row:last-child { border-bottom: none; }
+.sync-status-row .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
+.sync-status-row .value { font-weight: 600; }
+.sync-status-row code {
+  font-family: 'SF Mono', Monaco, Consolas, monospace;
+  background: rgba(255,255,255,0.05);
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--accent-2);
+}
+
 /* ---------- Responsive ---------- */
 @media (max-width: 800px) {
   .topbar { flex-direction: column; align-items: stretch; gap: 12px; padding: 14px; }

--- a/styles.css
+++ b/styles.css
@@ -1,32 +1,35 @@
 /* ============================================================
-   Budget Quest — Theme
-   A neon/glassmorphism vibe with animated gradients & glow.
+   Budget Quest — clean, friendly light theme.
+   Soft cream/peach background, indigo/coral/mint accents,
+   gentle shadows, no particle background.
    ============================================================ */
 
 :root {
-  --bg-0: #0a0a18;
-  --bg-1: #110a2e;
-  --bg-2: #1f0a3a;
-  --ink: #f3f0ff;
-  --ink-dim: #b9b3d6;
-  --muted: #8a85a8;
-  --line: rgba(255, 255, 255, 0.08);
-  --glass: rgba(255, 255, 255, 0.06);
-  --glass-strong: rgba(255, 255, 255, 0.10);
-  --accent: #7c5cff;
-  --accent-2: #00e0ff;
-  --accent-3: #ff5cf3;
-  --good: #2bd99f;
-  --warn: #ffb648;
-  --bad: #ff4d6d;
-  --shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
-  --radius: 16px;
+  --bg-0: #fefaf6;        /* cream base */
+  --bg-1: #fff5f0;        /* peach */
+  --bg-2: #f5f0fa;        /* faint lavender */
+  --surface: #ffffff;
+  --surface-2: #fafafa;
+  --ink: #1f2937;         /* dark slate */
+  --ink-dim: #475569;
+  --muted: #94a3b8;
+  --line: rgba(15, 23, 42, 0.08);
+  --line-strong: rgba(15, 23, 42, 0.14);
+  --accent: #6366f1;      /* indigo */
+  --accent-2: #f43f5e;    /* rose / coral */
+  --accent-3: #f59e0b;    /* warm amber */
+  --good: #10b981;        /* emerald */
+  --warn: #f59e0b;        /* amber */
+  --bad: #ef4444;         /* red */
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 3px rgba(15, 23, 42, 0.06);
+  --shadow: 0 4px 12px rgba(15, 23, 42, 0.06), 0 2px 4px rgba(15, 23, 42, 0.04);
+  --shadow-lg: 0 12px 32px rgba(15, 23, 42, 0.10), 0 4px 8px rgba(15, 23, 42, 0.06);
+  --radius: 14px;
 }
 
 * { box-sizing: border-box; }
 
 html {
-  /* Solid base color so overscroll / rubber-band never shows white. */
   background-color: var(--bg-0);
 }
 
@@ -41,42 +44,20 @@ html, body {
 }
 
 body {
-  /* Fallback in case the fixed gradient layer fails to paint. */
   background-color: var(--bg-0);
 }
 
-/* Fixed gradient layer — using a dedicated pseudo-element instead of
-   `background-attachment: fixed` on body avoids the per-scroll repaint
-   that caused a white flash at the bottom on slower frames. */
+/* Soft warm gradient — no neon, no cosmic glow. */
 body::before {
   content: '';
   position: fixed;
   inset: 0;
   z-index: -2;
   pointer-events: none;
-  background: radial-gradient(1200px 800px at 80% -10%, #2a0e6e 0%, transparent 60%),
-              radial-gradient(1000px 700px at -10% 110%, #003d66 0%, transparent 55%),
-              linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 50%, var(--bg-2) 100%);
-}
-
-/* Scanline overlay (was previously on body::before). */
-body::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  background: repeating-linear-gradient(0deg, rgba(255,255,255,0.02) 0 1px, transparent 1px 3px);
-  mix-blend-mode: overlay;
-  opacity: 0.35;
-  z-index: 0;
-}
-
-#bg-canvas {
-  position: fixed;
-  inset: 0;
-  width: 100%; height: 100%;
-  z-index: -1;
-  filter: blur(0.4px);
+  background:
+    radial-gradient(900px 600px at 90% -10%, #ffe4e9 0%, transparent 60%),
+    radial-gradient(800px 600px at -10% 110%, #e0f2fe 0%, transparent 55%),
+    linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 100%);
 }
 
 #confetti-layer {
@@ -104,10 +85,10 @@ main {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 18px 24px;
-  background: linear-gradient(180deg, rgba(10,10,24,0.85), rgba(10,10,24,0.55));
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
+  padding: 16px 24px;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--line);
 }
 
@@ -118,29 +99,28 @@ main {
 }
 
 .logo {
-  font-size: 30px;
-  filter: drop-shadow(0 0 12px rgba(124, 92, 255, 0.6));
+  font-size: 28px;
   animation: float 4s ease-in-out infinite;
 }
 
 .brand-text h1 {
   margin: 0;
   font-size: 22px;
-  background: linear-gradient(90deg, #fff, var(--accent-2), var(--accent-3), var(--accent), #fff);
-  background-size: 300% 100%;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-  letter-spacing: 0.5px;
-  animation: shimmer 6s linear infinite;
+  letter-spacing: -0.3px;
 }
 
 .brand-text .tagline {
   margin: 2px 0 0;
   font-size: 11px;
-  letter-spacing: 2px;
+  letter-spacing: 1.5px;
   text-transform: uppercase;
   color: var(--muted);
+  font-weight: 500;
 }
 
 .month-switcher {
@@ -155,14 +135,16 @@ main {
   align-items: center;
   min-width: 140px;
   padding: 6px 14px;
-  border-radius: 12px;
-  background: var(--glass);
+  border-radius: 10px;
+  background: var(--surface);
   border: 1px solid var(--line);
+  box-shadow: var(--shadow-sm);
 }
 
 .month-label span {
   font-weight: 600;
-  font-size: 15px;
+  font-size: 14px;
+  color: var(--ink);
 }
 
 .month-label small {
@@ -170,144 +152,128 @@ main {
   color: var(--muted);
   letter-spacing: 1.5px;
   text-transform: uppercase;
+  font-weight: 600;
 }
 
 .icon-btn {
   width: 36px; height: 36px;
   border-radius: 10px;
   border: 1px solid var(--line);
-  background: var(--glass);
+  background: var(--surface);
   color: var(--ink);
-  font-size: 20px;
+  font-size: 18px;
   cursor: pointer;
-  transition: transform 0.15s ease, background 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s ease, background 0.2s ease, border-color 0.2s ease;
 }
 .icon-btn:hover {
   transform: translateY(-1px);
-  background: var(--glass-strong);
-  box-shadow: 0 0 18px rgba(124, 92, 255, 0.35);
+  background: var(--bg-1);
+  border-color: var(--line-strong);
 }
 
 .ghost-btn {
   border: 1px solid var(--line);
-  background: var(--glass);
+  background: var(--surface);
   color: var(--ink);
   padding: 8px 14px;
   border-radius: 10px;
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
+  box-shadow: var(--shadow-sm);
+  transition: all 0.18s ease;
 }
 .ghost-btn:hover {
-  background: var(--glass-strong);
-  border-color: rgba(255,255,255,0.18);
+  background: var(--bg-1);
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
 }
 
 .primary-btn {
   border: none;
-  background: linear-gradient(135deg, var(--accent), var(--accent-3));
+  background: var(--accent);
   color: #fff;
   padding: 9px 16px;
   border-radius: 10px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  letter-spacing: 0.3px;
-  position: relative;
-  overflow: hidden;
-  box-shadow: 0 4px 18px rgba(124, 92, 255, 0.45);
-  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  letter-spacing: 0.2px;
+  box-shadow: 0 2px 6px rgba(99, 102, 241, 0.3);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 .primary-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 28px rgba(255, 92, 243, 0.55);
+  background: #4f52ef;
+  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.4);
 }
 .primary-btn:active { transform: translateY(0); }
-.primary-btn::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, transparent 30%, rgba(255,255,255,0.35) 50%, transparent 70%);
-  transform: translateX(-100%);
-  transition: transform 0.6s ease;
-}
-.primary-btn:hover::before { transform: translateX(100%); }
 
 .danger-btn {
   border: none;
-  background: linear-gradient(135deg, #ff4d6d, #ff7a3c);
+  background: var(--bad);
   color: #fff;
   padding: 9px 16px;
   border-radius: 10px;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 4px 18px rgba(255, 77, 109, 0.4);
+  box-shadow: 0 2px 6px rgba(239, 68, 68, 0.3);
   transition: transform 0.15s ease;
 }
-.danger-btn:hover { transform: translateY(-1px); }
+.danger-btn:hover { transform: translateY(-1px); background: #dc2626; }
 
 /* ---------- Dashboard ---------- */
 .dashboard {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 14px;
-  margin-bottom: 28px;
+  margin: 28px 0;
 }
 
 .stat-card {
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 18px 18px;
+  padding: 18px;
   border-radius: var(--radius);
-  background: linear-gradient(160deg, var(--glass-strong), var(--glass));
+  background: var(--surface);
   border: 1px solid var(--line);
-  position: relative;
-  overflow: hidden;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
-}
-.stat-card::before {
-  content: '';
-  position: absolute;
-  inset: -2px;
-  background: conic-gradient(from var(--angle, 0deg), transparent 0%, var(--card-glow, var(--accent)) 30%, transparent 60%);
-  filter: blur(20px);
-  opacity: 0.35;
-  z-index: -1;
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 .stat-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 12px 30px rgba(0,0,0,0.35);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
 }
-.stat-income { --card-glow: var(--good); }
-.stat-budget { --card-glow: var(--accent); }
-.stat-spent  { --card-glow: var(--warn); }
+.stat-income    { --card-glow: var(--good); }
+.stat-budget    { --card-glow: var(--accent); }
+.stat-spent     { --card-glow: var(--warn); }
 .stat-remaining { --card-glow: var(--accent-2); }
 
 .stat-icon {
-  font-size: 28px;
-  width: 50px; height: 50px;
+  font-size: 24px;
+  width: 48px; height: 48px;
   display: grid; place-items: center;
   border-radius: 12px;
-  background: rgba(255,255,255,0.05);
-  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--card-glow) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--card-glow) 25%, transparent);
 }
 
 .stat-body { display: flex; flex-direction: column; }
 .stat-label {
   font-size: 11px;
-  letter-spacing: 1.5px;
+  letter-spacing: 1.2px;
   text-transform: uppercase;
   color: var(--muted);
+  font-weight: 600;
 }
 .stat-value {
   font-size: 22px;
   font-weight: 700;
   margin-top: 2px;
   font-variant-numeric: tabular-nums;
+  color: var(--ink);
 }
 
 /* ---------- Sections ---------- */
@@ -323,7 +289,9 @@ main {
 .section-header h2 {
   margin: 0;
   font-size: 18px;
-  letter-spacing: 0.3px;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: -0.2px;
 }
 
 /* ---------- Income list ---------- */
@@ -338,11 +306,11 @@ main {
   align-items: center;
   padding: 12px 14px;
   border-radius: 12px;
-  background: linear-gradient(135deg, rgba(43, 217, 159, 0.12), rgba(43, 217, 159, 0.04));
-  border: 1px solid rgba(43, 217, 159, 0.25);
-  animation: pop-in 0.35s ease backwards;
+  background: color-mix(in srgb, var(--good) 8%, white);
+  border: 1px solid color-mix(in srgb, var(--good) 25%, transparent);
+  animation: pop-in 0.3s ease backwards;
 }
-.income-item .name { font-weight: 500; }
+.income-item .name { font-weight: 500; color: var(--ink); }
 .income-item .amount {
   color: var(--good);
   font-weight: 700;
@@ -353,11 +321,11 @@ main {
   border: none;
   color: var(--muted);
   cursor: pointer;
-  font-size: 16px;
+  font-size: 18px;
   padding: 0 4px;
   margin-left: 6px;
   opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease, color 0.2s ease;
 }
 .income-item:hover .delete { opacity: 1; }
 .income-item .delete:hover { color: var(--bad); }
@@ -366,8 +334,9 @@ main {
   padding: 18px;
   text-align: center;
   color: var(--muted);
-  border: 1px dashed var(--line);
+  border: 1px dashed var(--line-strong);
   border-radius: 12px;
+  background: var(--surface);
 }
 
 /* ---------- Categories grid ---------- */
@@ -381,30 +350,27 @@ main {
   position: relative;
   padding: 18px;
   border-radius: var(--radius);
-  background: linear-gradient(160deg, var(--glass-strong), var(--glass));
+  background: var(--surface);
   border: 1px solid var(--line);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  box-shadow: var(--shadow);
   overflow: hidden;
-  animation: pop-in 0.4s ease backwards;
-  transition: transform 0.25s ease, box-shadow 0.3s ease;
+  animation: pop-in 0.35s ease backwards;
+  transition: transform 0.2s ease, box-shadow 0.25s ease;
 }
 .category-card::before {
   content: '';
   position: absolute;
   top: 0; left: 0; right: 0;
   height: 3px;
-  background: linear-gradient(90deg, var(--cat-color, var(--accent)), transparent);
-  opacity: 0.9;
+  background: var(--cat-color, var(--accent));
 }
 .category-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 14px 40px rgba(0,0,0,0.4),
-              0 0 30px color-mix(in srgb, var(--cat-color, var(--accent)) 25%, transparent);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
 }
 .category-card.over {
-  animation: pop-in 0.4s ease backwards, shake 0.7s ease;
-  border-color: rgba(255, 77, 109, 0.45);
+  animation: pop-in 0.35s ease backwards, shake 0.6s ease;
+  border-color: color-mix(in srgb, var(--bad) 50%, transparent);
 }
 
 .cat-head {
@@ -414,12 +380,12 @@ main {
   margin-bottom: 14px;
 }
 .cat-icon {
-  font-size: 24px;
-  width: 44px; height: 44px;
+  font-size: 22px;
+  width: 42px; height: 42px;
   display: grid; place-items: center;
   border-radius: 12px;
-  background: color-mix(in srgb, var(--cat-color, var(--accent)) 18%, transparent);
-  border: 1px solid color-mix(in srgb, var(--cat-color, var(--accent)) 35%, transparent);
+  background: color-mix(in srgb, var(--cat-color, var(--accent)) 14%, white);
+  border: 1px solid color-mix(in srgb, var(--cat-color, var(--accent)) 25%, transparent);
 }
 .cat-title {
   flex: 1;
@@ -429,28 +395,30 @@ main {
 .cat-name {
   font-size: 16px;
   font-weight: 700;
+  color: var(--ink);
 }
 .cat-amounts {
   font-size: 12px;
   color: var(--muted);
   font-variant-numeric: tabular-nums;
+  margin-top: 2px;
 }
 .cat-actions {
   display: flex;
   gap: 4px;
 }
 .cat-actions button {
-  background: none;
+  background: transparent;
   border: 1px solid transparent;
   color: var(--ink-dim);
   width: 30px; height: 30px;
   border-radius: 8px;
   cursor: pointer;
   font-size: 13px;
-  transition: all 0.18s ease;
+  transition: all 0.15s ease;
 }
 .cat-actions button:hover {
-  background: var(--glass-strong);
+  background: var(--bg-1);
   color: var(--ink);
   border-color: var(--line);
 }
@@ -458,39 +426,27 @@ main {
 /* progress bar */
 .bar {
   position: relative;
-  height: 14px;
+  height: 12px;
   border-radius: 999px;
-  background: rgba(255,255,255,0.06);
+  background: rgba(15, 23, 42, 0.06);
   overflow: hidden;
-  border: 1px solid var(--line);
 }
 .bar-fill {
   position: absolute;
   inset: 0;
   width: 0%;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--cat-color, var(--accent)), color-mix(in srgb, var(--cat-color, var(--accent)) 30%, var(--accent-2)));
-  transition: width 0.8s cubic-bezier(0.22, 1, 0.36, 1), background 0.3s ease;
-  box-shadow: 0 0 12px color-mix(in srgb, var(--cat-color, var(--accent)) 60%, transparent);
-}
-.bar-fill::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(90deg, transparent 30%, rgba(255,255,255,0.35) 50%, transparent 70%);
-  background-size: 200% 100%;
-  animation: stripe 2.5s linear infinite;
-  border-radius: 999px;
+  background: linear-gradient(90deg,
+    var(--cat-color, var(--accent)),
+    color-mix(in srgb, var(--cat-color, var(--accent)) 70%, white));
+  transition: width 0.7s cubic-bezier(0.22, 1, 0.36, 1), background 0.3s ease;
 }
 .bar.warn .bar-fill {
-  background: linear-gradient(90deg, var(--warn), #ff7a3c);
-  box-shadow: 0 0 14px rgba(255, 182, 72, 0.5);
+  background: linear-gradient(90deg, var(--warn), #fbbf24);
 }
 .bar.over .bar-fill {
-  background: linear-gradient(90deg, #ff4d6d, #ff2d8a, #ff4d6d);
-  background-size: 200% 100%;
+  background: linear-gradient(90deg, var(--bad), #f87171);
   animation: pulse-red 1.6s ease-in-out infinite;
-  box-shadow: 0 0 18px rgba(255, 77, 109, 0.7);
 }
 
 .bar-meta {
@@ -509,32 +465,34 @@ main {
 .bar-meta .over-tag {
   font-size: 11px;
   color: #fff;
-  background: linear-gradient(135deg, #ff4d6d, #ff2d8a);
+  background: var(--bad);
   padding: 2px 8px;
   border-radius: 999px;
   margin-left: 6px;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.4px;
   font-weight: 700;
-  animation: pulse-red 1.6s ease-in-out infinite;
 }
 
 /* sub-budgets */
 .subs {
   margin-top: 14px;
   padding-top: 14px;
-  border-top: 1px dashed var(--line);
+  border-top: 1px dashed var(--line-strong);
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 .sub {
-  padding: 8px 10px;
+  padding: 10px 12px;
   border-radius: 10px;
-  background: rgba(255,255,255,0.03);
+  background: var(--surface-2);
   border: 1px solid var(--line);
-  transition: background 0.2s ease;
+  transition: background 0.18s ease, border-color 0.18s ease;
 }
-.sub:hover { background: rgba(255,255,255,0.05); }
+.sub:hover {
+  background: var(--bg-1);
+  border-color: var(--line-strong);
+}
 .sub-head {
   display: flex;
   justify-content: space-between;
@@ -542,71 +500,71 @@ main {
   margin-bottom: 6px;
   gap: 8px;
 }
-.sub-name { font-size: 13px; font-weight: 600; }
-.sub-amounts { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.sub-name { font-size: 13px; font-weight: 600; color: var(--ink); }
+.sub-amounts { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; margin-top: 2px; }
 .sub-actions { display: flex; gap: 2px; }
 .sub-actions button {
-  background: none;
+  background: transparent;
   border: none;
   color: var(--muted);
   cursor: pointer;
   font-size: 12px;
-  padding: 2px 6px;
+  padding: 3px 8px;
   border-radius: 6px;
   transition: all 0.15s ease;
 }
-.sub-actions button:hover { background: var(--glass-strong); color: var(--ink); }
-.sub .bar { height: 8px; }
+.sub-actions button:hover { background: var(--surface); color: var(--ink); }
+.sub .bar { height: 6px; }
 
 .cat-add-sub {
   margin-top: 10px;
   width: 100%;
-  border: 1px dashed var(--line);
+  border: 1px dashed var(--line-strong);
   background: transparent;
   color: var(--ink-dim);
   padding: 8px;
   border-radius: 10px;
   cursor: pointer;
   font-size: 12px;
-  transition: all 0.2s ease;
+  font-weight: 500;
+  transition: all 0.18s ease;
 }
 .cat-add-sub:hover {
-  border-color: color-mix(in srgb, var(--cat-color, var(--accent)) 60%, transparent);
-  color: var(--ink);
-  background: color-mix(in srgb, var(--cat-color, var(--accent)) 8%, transparent);
+  border-color: var(--cat-color, var(--accent));
+  color: var(--cat-color, var(--accent));
+  background: color-mix(in srgb, var(--cat-color, var(--accent)) 6%, transparent);
 }
 
-/* expenses list (collapsible, simple) */
+/* expenses list (chips) */
 .recent {
-  margin-top: 10px;
+  margin-top: 12px;
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
 .recent .chip {
   font-size: 11px;
-  padding: 3px 8px;
+  padding: 3px 10px;
   border-radius: 999px;
-  background: rgba(255,255,255,0.05);
+  background: var(--bg-1);
   border: 1px solid var(--line);
   color: var(--ink-dim);
 }
-.recent .chip strong { color: var(--ink); margin-left: 4px; }
+.recent .chip strong { color: var(--ink); margin-left: 4px; font-variant-numeric: tabular-nums; }
 
 /* ---------- Empty state ---------- */
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  border: 1px dashed var(--line);
+  border: 1px dashed var(--line-strong);
   border-radius: 18px;
-  background: var(--glass);
+  background: var(--surface);
 }
 .empty-art {
-  font-size: 60px;
-  filter: drop-shadow(0 0 20px rgba(124, 92, 255, 0.5));
+  font-size: 56px;
   animation: float 3.5s ease-in-out infinite;
 }
-.empty-state h3 { margin: 12px 0 4px; }
+.empty-state h3 { margin: 12px 0 4px; color: var(--ink); }
 .empty-state p { color: var(--muted); margin: 0 0 18px; }
 
 /* ---------- Modals ---------- */
@@ -617,35 +575,39 @@ main {
   display: grid;
   place-items: center;
   padding: 20px;
-  animation: fade-in 0.2s ease;
+  animation: fade-in 0.18s ease;
 }
 .modal[hidden] { display: none; }
 .modal-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
+  background: rgba(15, 23, 42, 0.32);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 .modal-card {
   position: relative;
   width: 100%;
   max-width: 440px;
   padding: 28px;
-  border-radius: 20px;
-  background: linear-gradient(160deg, #1a1538, #110a2e);
+  border-radius: 18px;
+  background: var(--surface);
   border: 1px solid var(--line);
-  box-shadow: 0 30px 80px rgba(0,0,0,0.6),
-              0 0 60px rgba(124, 92, 255, 0.25);
-  animation: zoom-in 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.18);
+  animation: zoom-in 0.22s cubic-bezier(0.34, 1.4, 0.64, 1);
 }
 .modal-wide { max-width: 700px; }
 .modal-narrow { max-width: 360px; }
-.modal-card h3 { margin: 0 0 18px; }
+.modal-card h3 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 18px;
+  font-weight: 700;
+}
 .modal-close {
   position: absolute;
   top: 12px; right: 14px;
-  background: none;
+  background: transparent;
   border: none;
   color: var(--muted);
   font-size: 26px;
@@ -655,15 +617,16 @@ main {
   border-radius: 8px;
   transition: all 0.15s ease;
 }
-.modal-close:hover { color: var(--ink); background: var(--glass); }
+.modal-close:hover { color: var(--ink); background: var(--bg-1); }
 
 .modal-card label {
   display: block;
   font-size: 12px;
   color: var(--ink-dim);
-  letter-spacing: 0.5px;
+  letter-spacing: 0.4px;
   text-transform: uppercase;
   margin-bottom: 14px;
+  font-weight: 600;
 }
 .modal-card input[type="text"],
 .modal-card input[type="number"] {
@@ -671,18 +634,19 @@ main {
   width: 100%;
   margin-top: 6px;
   padding: 10px 12px;
-  background: rgba(255,255,255,0.04);
+  background: var(--bg-1);
   border: 1px solid var(--line);
   border-radius: 10px;
   color: var(--ink);
   font-size: 14px;
   font-family: inherit;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
 }
 .modal-card input:focus {
   outline: none;
+  background: var(--surface);
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.18);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .emoji-grid, .color-grid {
@@ -693,31 +657,32 @@ main {
 }
 .emoji-grid button {
   width: 36px; height: 36px;
-  background: rgba(255,255,255,0.04);
+  background: var(--bg-1);
   border: 1px solid var(--line);
   border-radius: 10px;
   font-size: 18px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
-.emoji-grid button:hover { background: rgba(255,255,255,0.1); transform: scale(1.1); }
+.emoji-grid button:hover { background: var(--surface); transform: scale(1.08); }
 .emoji-grid button.active {
-  background: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, white);
   border-color: var(--accent);
-  box-shadow: 0 0 14px rgba(124, 92, 255, 0.6);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .color-grid button {
   width: 28px; height: 28px;
   border-radius: 50%;
-  border: 2px solid transparent;
+  border: 2px solid white;
+  outline: 1px solid var(--line);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 .color-grid button:hover { transform: scale(1.15); }
 .color-grid button.active {
-  border-color: #fff;
-  box-shadow: 0 0 0 3px rgba(255,255,255,0.15);
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
 }
 
 .modal-actions {
@@ -741,21 +706,22 @@ main {
   cursor: pointer;
   padding: 14px;
   border-radius: 12px;
-  background: var(--glass);
+  background: var(--surface);
   border: 1px solid var(--line);
-  transition: all 0.2s ease;
+  box-shadow: var(--shadow-sm);
+  transition: all 0.18s ease;
 }
 .history-item:hover {
-  background: var(--glass-strong);
+  background: var(--bg-1);
   transform: translateY(-2px);
   border-color: var(--accent);
-  box-shadow: 0 6px 20px rgba(124, 92, 255, 0.3);
+  box-shadow: var(--shadow);
 }
 .history-item.current {
-  border-color: var(--accent-2);
-  box-shadow: 0 0 16px rgba(0, 224, 255, 0.25);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 5%, white);
 }
-.history-month { font-weight: 700; font-size: 14px; }
+.history-month { font-weight: 700; font-size: 14px; color: var(--ink); }
 .history-stats { font-size: 11px; color: var(--muted); margin-top: 6px; }
 .history-stats div { display: flex; justify-content: space-between; }
 .history-stats .saved { color: var(--good); font-weight: 600; }
@@ -776,74 +742,17 @@ main {
   pointer-events: auto;
   padding: 12px 16px;
   border-radius: 12px;
-  background: linear-gradient(135deg, #1a1538, #110a2e);
+  background: var(--surface);
   border: 1px solid var(--line);
   color: var(--ink);
   font-size: 13px;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+  box-shadow: var(--shadow-lg);
   animation: slide-in 0.3s ease, fade-out 0.4s ease 2.6s forwards;
   max-width: 320px;
 }
 .toast.success { border-left: 3px solid var(--good); }
 .toast.error   { border-left: 3px solid var(--bad); }
-.toast.info    { border-left: 3px solid var(--accent-2); }
-
-/* ---------- Animations ---------- */
-@keyframes float {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-4px); }
-}
-@keyframes shimmer {
-  0% { background-position: 0% 50%; }
-  100% { background-position: 300% 50%; }
-}
-@keyframes stripe {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-@keyframes pulse-red {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-}
-@keyframes pop-in {
-  0% { opacity: 0; transform: translateY(8px) scale(0.96); }
-  100% { opacity: 1; transform: translateY(0) scale(1); }
-}
-@keyframes zoom-in {
-  0% { opacity: 0; transform: scale(0.9); }
-  100% { opacity: 1; transform: scale(1); }
-}
-@keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-@keyframes slide-in {
-  from { opacity: 0; transform: translateX(20px); }
-  to { opacity: 1; transform: translateX(0); }
-}
-@keyframes fade-out {
-  to { opacity: 0; transform: translateX(20px); }
-}
-@keyframes shake {
-  0%, 100% { transform: translateX(0); }
-  20%, 60% { transform: translateX(-4px); }
-  40%, 80% { transform: translateX(4px); }
-}
-
-/* ---------- Confetti ---------- */
-.confetti {
-  position: absolute;
-  width: 8px; height: 14px;
-  border-radius: 2px;
-  top: -20px;
-  animation: fall linear forwards;
-}
-@keyframes fall {
-  to {
-    transform: translateY(110vh) rotate(720deg);
-    opacity: 0;
-  }
-}
+.toast.info    { border-left: 3px solid var(--accent); }
 
 /* ---------- Sync indicator ---------- */
 .sync-indicator {
@@ -853,31 +762,31 @@ main {
   padding: 7px 12px;
   border-radius: 999px;
   border: 1px solid var(--line);
-  background: var(--glass);
+  background: var(--surface);
   color: var(--ink-dim);
   font-size: 12px;
   font-weight: 500;
-  letter-spacing: 0.3px;
+  letter-spacing: 0.2px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  box-shadow: var(--shadow-sm);
+  transition: all 0.18s ease;
 }
-.sync-indicator:hover { background: var(--glass-strong); color: var(--ink); }
+.sync-indicator:hover { background: var(--bg-1); color: var(--ink); }
 .sync-indicator .sync-dot {
   width: 8px; height: 8px;
   border-radius: 50%;
   background: var(--muted);
-  box-shadow: 0 0 0 0 currentColor;
 }
 .sync-indicator.synced     .sync-dot { background: var(--good); animation: pulse-dot 2.4s ease-in-out infinite; }
-.sync-indicator.syncing    .sync-dot { background: var(--accent-2); animation: pulse-dot 0.9s ease-in-out infinite; }
+.sync-indicator.syncing    .sync-dot { background: var(--accent); animation: pulse-dot 0.9s ease-in-out infinite; }
 .sync-indicator.connecting .sync-dot { background: var(--warn); animation: pulse-dot 1.2s ease-in-out infinite; }
 .sync-indicator.offline    .sync-dot { background: var(--muted); }
 .sync-indicator.error      .sync-dot { background: var(--bad); animation: pulse-dot 0.7s ease-in-out infinite; }
 .sync-indicator.local      .sync-dot { background: var(--muted); }
 
 @keyframes pulse-dot {
-  0%, 100% { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
-  50% { box-shadow: 0 0 0 4px transparent; opacity: 0.6; }
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.85); }
 }
 
 /* ---------- Household modal ---------- */
@@ -885,7 +794,7 @@ main {
   display: flex;
   gap: 4px;
   padding: 4px;
-  background: rgba(255,255,255,0.04);
+  background: var(--bg-1);
   border-radius: 12px;
   margin-bottom: 18px;
 }
@@ -899,13 +808,13 @@ main {
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.18s ease;
 }
 .hh-tab:hover { color: var(--ink); }
 .hh-tab.active {
-  background: linear-gradient(135deg, var(--accent), var(--accent-3));
-  color: #fff;
-  box-shadow: 0 2px 12px rgba(124, 92, 255, 0.4);
+  background: var(--surface);
+  color: var(--accent);
+  box-shadow: var(--shadow-sm);
 }
 
 .hh-code-display {
@@ -914,7 +823,7 @@ main {
   gap: 8px;
   margin-top: 6px;
   padding: 12px 14px;
-  background: rgba(255,255,255,0.04);
+  background: var(--bg-1);
   border: 1px solid var(--line);
   border-radius: 10px;
 }
@@ -922,8 +831,8 @@ main {
   flex: 1;
   font-family: 'SF Mono', 'Monaco', Consolas, monospace;
   font-size: 16px;
-  letter-spacing: 1px;
-  color: var(--accent-2);
+  letter-spacing: 0.5px;
+  color: var(--accent);
   font-weight: 600;
 }
 .hh-code-display .icon-btn { width: 32px; height: 32px; font-size: 16px; }
@@ -940,15 +849,64 @@ main {
   font-size: 14px;
 }
 .sync-status-row:last-child { border-bottom: none; }
-.sync-status-row .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
-.sync-status-row .value { font-weight: 600; }
+.sync-status-row .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.4px; font-weight: 600; }
+.sync-status-row .value { font-weight: 600; color: var(--ink); }
 .sync-status-row code {
   font-family: 'SF Mono', Monaco, Consolas, monospace;
-  background: rgba(255,255,255,0.05);
+  background: var(--bg-1);
   padding: 4px 8px;
   border-radius: 6px;
   font-size: 13px;
-  color: var(--accent-2);
+  color: var(--accent);
+}
+
+/* ---------- Animations ---------- */
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+@keyframes pulse-red {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+@keyframes pop-in {
+  0% { opacity: 0; transform: translateY(6px) scale(0.98); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes zoom-in {
+  0% { opacity: 0; transform: scale(0.94); }
+  100% { opacity: 1; transform: scale(1); }
+}
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes slide-in {
+  from { opacity: 0; transform: translateX(20px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes fade-out {
+  to { opacity: 0; transform: translateX(20px); }
+}
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-3px); }
+  40%, 80% { transform: translateX(3px); }
+}
+
+/* ---------- Confetti ---------- */
+.confetti {
+  position: absolute;
+  width: 8px; height: 14px;
+  border-radius: 2px;
+  top: -20px;
+  animation: fall linear forwards;
+}
+@keyframes fall {
+  to {
+    transform: translateY(110vh) rotate(720deg);
+    opacity: 0;
+  }
 }
 
 /* ---------- Responsive ---------- */

--- a/sync.js
+++ b/sync.js
@@ -1,0 +1,137 @@
+/* ===========================================================
+   Budget Quest — Firebase sync layer
+   - Anonymous auth (so Firestore rules can require auth)
+   - One Firestore document per household, real-time listener
+   - Whole-state last-write-wins; debounced pushes
+   =========================================================== */
+
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.13.1/firebase-app.js';
+import {
+  getAuth, signInAnonymously, onAuthStateChanged
+} from 'https://www.gstatic.com/firebasejs/10.13.1/firebase-auth.js';
+import {
+  getFirestore, doc, setDoc, getDoc, onSnapshot, serverTimestamp
+} from 'https://www.gstatic.com/firebasejs/10.13.1/firebase-firestore.js';
+
+let app = null;
+let auth = null;
+let db = null;
+let unsubscribeSnap = null;
+let currentCode = null;
+let onRemoteCb = null;
+let onStatusCb = null;
+let lastPushedPayload = null;
+let pushTimer = null;
+let initialized = false;
+
+function setStatus(s) { if (onStatusCb) onStatusCb(s); }
+
+export function isConfigured(config) {
+  if (!config) return false;
+  const required = ['apiKey', 'authDomain', 'projectId', 'appId'];
+  for (const k of required) {
+    const v = config[k];
+    if (!v || typeof v !== 'string') return false;
+    if (v.includes('YOUR_')) return false;
+  }
+  return true;
+}
+
+export function isValidCode(code) {
+  if (!code || typeof code !== 'string') return false;
+  const trimmed = code.trim();
+  return trimmed.length >= 6 && trimmed.length <= 50 && /^[a-z0-9-]+$/i.test(trimmed);
+}
+
+export function onStatus(cb) { onStatusCb = cb; }
+
+export async function init(config) {
+  if (initialized) return;
+  app = initializeApp(config);
+  auth = getAuth(app);
+  db = getFirestore(app);
+  setStatus('connecting');
+  await signInAnonymously(auth);
+  await new Promise(resolve => {
+    const stop = onAuthStateChanged(auth, user => {
+      if (user) { stop(); resolve(user); }
+    });
+  });
+  initialized = true;
+}
+
+/**
+ * Join (or create) a household document. Subscribes to remote changes.
+ * Returns the existing remote payload (or null if the household is new).
+ */
+export async function joinHousehold(code, onRemote) {
+  if (!initialized) throw new Error('sync.init() must be called first');
+  if (unsubscribeSnap) { unsubscribeSnap(); unsubscribeSnap = null; }
+
+  currentCode = code.trim().toLowerCase();
+  onRemoteCb = onRemote;
+
+  const ref = doc(db, 'households', currentCode);
+  setStatus('connecting');
+  const snap = await getDoc(ref);
+  const existing = snap.exists() && snap.data().payload
+    ? safeParse(snap.data().payload)
+    : null;
+
+  unsubscribeSnap = onSnapshot(ref, (snap) => {
+    if (!snap.exists()) return;
+    const data = snap.data();
+    if (!data || !data.payload) return;
+    if (data.payload === lastPushedPayload) {
+      // This snapshot is from our own write
+      setStatus('synced');
+      return;
+    }
+    const remote = safeParse(data.payload);
+    if (remote && onRemoteCb) {
+      onRemoteCb(remote);
+      setStatus('synced');
+    }
+  }, (err) => {
+    console.warn('Firestore listener error', err);
+    setStatus('error');
+  });
+
+  setStatus('synced');
+  return existing;
+}
+
+/**
+ * Push the current local state. Debounced so rapid edits coalesce.
+ */
+export function pushLocal(state) {
+  if (!currentCode || !db) return;
+  clearTimeout(pushTimer);
+  setStatus('syncing');
+  pushTimer = setTimeout(async () => {
+    try {
+      const payload = JSON.stringify(state);
+      lastPushedPayload = payload;
+      const ref = doc(db, 'households', currentCode);
+      await setDoc(ref, { payload, updatedAt: serverTimestamp() });
+      setStatus('synced');
+    } catch (e) {
+      console.warn('Sync push failed', e);
+      setStatus('error');
+    }
+  }, 500);
+}
+
+export function disconnect() {
+  if (unsubscribeSnap) { unsubscribeSnap(); unsubscribeSnap = null; }
+  currentCode = null;
+  onRemoteCb = null;
+  lastPushedPayload = null;
+  setStatus('local');
+}
+
+export function getCurrentCode() { return currentCode; }
+
+function safeParse(s) {
+  try { return JSON.parse(s); } catch { return null; }
+}


### PR DESCRIPTION
## Summary

Replaces the scaffolded Rails app with **Budget Quest** — a single-page vanilla-JS budget tracker. Deploys as a static site to GitHub Pages and optionally syncs across devices via Firebase Firestore.

### What's in it

- **Categories** with animated progress bars (custom name, $ limit, emoji, color); add/remove/edit at will.
- **Sub-budgets** inside each category, each with its own progress bar (e.g. Food → Groceries / Eating Out).
- **Over-budget feedback** — bars pulse red, the card shakes, an "OVER $X" tag appears, warning toast fires. 80%+ shows a yellow warn state.
- **Income tracking** with confetti on add. Dashboard summarizes Income / Total Budget / Spent / Remaining.
- **Monthly reset** — "↻ New Month" archives the current month and starts fresh, carrying category structure forward with $0 spent.
- **History** view — read-only snapshots of every prior month.
- **Cross-device household sync** (optional, opt-in) — share a household code with your partner; edits propagate in real time via Firestore. Anonymous auth, debounced pushes, snapshot dedup so own writes don't echo. Falls back to local-only if `firebase-config.js` is left as placeholders.
- **Theme** — neon glassmorphism, animated particle-network canvas background, shimmer, pop-in animations, smooth toasts.

### Files

- `index.html`, `styles.css`, `app.js` — the app
- `sync.js` — Firebase wrapper (anonymous auth + Firestore real-time listener)
- `firebase-config.js` — config template, public-by-design
- `.github/workflows/deploy-pages.yml` — auto-deploys to GitHub Pages on push
- `README.md` — full Firebase setup walkthrough

### Notable fixes

- Scrolling no longer flashes white at the bottom (gradient moved off `body`'s `background-attachment: fixed` onto a fixed pseudo-layer; `html` gets a solid base color and `overscroll-behavior: none`).

## Test plan

- [ ] Open the live Pages URL and confirm the dashboard renders
- [ ] Add a category, add expenses, watch the progress bar grow + go red over limit
- [ ] Add a sub-budget inside a category, expense it, confirm both bars update
- [ ] Add income, confirm confetti and dashboard updates
- [ ] Click "↻ New Month" and confirm categories carry over with $0 spent
- [ ] Open History, confirm prior month is read-only
- [ ] Once Firebase is configured: create a household on one device, join on another, edit on each, confirm real-time sync
- [ ] Disconnect from household → confirm local-only fallback still works
- [ ] Scroll a long page — no white flash at the bottom

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_