### PR TITLE
Light theme, mobile scroll fix, drop sub-categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ Optional Firebase sync lets you and your partner share the same budget across de
 
 ## Features
 
-- **Budget categories** with animated progress bars that glow as you spend.
+- **Budget categories** with animated progress bars that fill as you spend.
 - **Over-budget alerts** — bars pulse red, the page shakes, and a warning toast pops up.
-- **Sub-budgets** inside each category for finer tracking (e.g. "Food → Groceries / Eating Out").
 - **Income tracker** with confetti when you add some.
 - **Monthly reset** — start a new month and your categories carry over with $0 spent.
 - **History** — flip back through previous months as read-only snapshots.

--- a/app.js
+++ b/app.js
@@ -28,21 +28,43 @@ import { firebaseConfig } from './firebase-config.js';
    *       income: [{id, name, amount}],
    *       categories: [{
    *         id, name, limit, color, icon,
-   *         expenses: [{id, name, amount}],
-   *         subs: [{id, name, limit, expenses: [...]}]
+   *         expenses: [{id, name, amount}]
    *       }]
    *     }
    *   }
    * }
    */
-  let data = load();
+  let data = migrate(load());
   let editingCategoryId = null;       // when set, category modal is editing
-  let activeExpenseTarget = null;     // {categoryId, subId|null}
-  let activeSubCategoryId = null;     // for sub-budget modal
+  let activeExpenseTarget = null;     // {categoryId}
   let viewingMonth = null;            // when viewing historical (read-only)
   let confirmAction = null;
   let syncState = 'local';            // local | connecting | synced | syncing | offline | error
   let suspendPush = false;            // true while applying a remote update
+
+  /**
+   * One-time migration: legacy categories may have a `subs` array with
+   * their own expenses. Flatten those into the parent's expenses and drop
+   * the subs field so existing users don't lose data.
+   */
+  function migrate(d) {
+    if (!d || !d.months) return d;
+    for (const key of Object.keys(d.months)) {
+      const m = d.months[key];
+      for (const cat of (m.categories || [])) {
+        if (Array.isArray(cat.subs) && cat.subs.length) {
+          cat.expenses = cat.expenses || [];
+          for (const sub of cat.subs) {
+            for (const e of (sub.expenses || [])) {
+              cat.expenses.push({ id: uid(), name: `${sub.name}: ${e.name}`, amount: e.amount });
+            }
+          }
+        }
+        delete cat.subs;
+      }
+    }
+    return d;
+  }
 
   // ---------- Storage ----------
   function load() {
@@ -105,15 +127,7 @@ import { firebaseConfig } from './firebase-config.js';
   }
 
   function categorySpent(cat) {
-    let total = (cat.expenses || []).reduce((s, e) => s + (+e.amount || 0), 0);
-    (cat.subs || []).forEach(sub => {
-      total += (sub.expenses || []).reduce((s, e) => s + (+e.amount || 0), 0);
-    });
-    return total;
-  }
-
-  function subSpent(sub) {
-    return (sub.expenses || []).reduce((s, e) => s + (+e.amount || 0), 0);
+    return (cat.expenses || []).reduce((s, e) => s + (+e.amount || 0), 0);
   }
 
   function totalIncome(m = getMonth()) {
@@ -263,35 +277,18 @@ import { firebaseConfig } from './firebase-config.js';
           ${over ? `<span class="over-tag">OVER ${fmt(spent - limit)}</span>` : ''}
         </span>
       </div>
-      <div class="subs-container"></div>
     `;
 
     card.querySelector('.cat-icon').textContent = cat.icon || '🛒';
     card.querySelector('.cat-name').textContent = cat.name;
     card.querySelector('.cat-amounts').textContent = `${fmt(spent)} of ${fmt(limit)}`;
 
-    // Sub-budgets
-    const subsContainer = card.querySelector('.subs-container');
-    if ((cat.subs && cat.subs.length) || !ro) {
-      const subs = document.createElement('div');
-      subs.className = 'subs';
-      (cat.subs || []).forEach(sub => subs.appendChild(renderSub(cat, sub)));
-      if (!ro) {
-        const add = document.createElement('button');
-        add.className = 'cat-add-sub';
-        add.textContent = '+ Add Sub-Budget';
-        add.addEventListener('click', () => openSubModal(cat.id));
-        subs.appendChild(add);
-      }
-      subsContainer.appendChild(subs);
-    }
-
-    // Recent direct expenses (chips)
-    const direct = (cat.expenses || []).slice(-3).reverse();
-    if (direct.length) {
+    // Recent expenses (chips)
+    const recentExpenses = (cat.expenses || []).slice(-3).reverse();
+    if (recentExpenses.length) {
       const recent = document.createElement('div');
       recent.className = 'recent';
-      direct.forEach(e => {
+      recentExpenses.forEach(e => {
         const chip = document.createElement('span');
         chip.className = 'chip';
         const nameSpan = document.createElement('span');
@@ -309,53 +306,13 @@ import { firebaseConfig } from './firebase-config.js';
     card.querySelectorAll('.cat-actions button').forEach(btn => {
       btn.addEventListener('click', () => {
         const act = btn.dataset.act;
-        if (act === 'add-expense') openExpenseModal(cat.id, null);
+        if (act === 'add-expense') openExpenseModal(cat.id);
         else if (act === 'edit') openCategoryModal(cat.id);
-        else if (act === 'delete') confirmDelete(`Delete "${cat.name}"?`, 'All expenses & sub-budgets in this category will be removed.', () => deleteCategory(cat.id));
+        else if (act === 'delete') confirmDelete(`Delete "${cat.name}"?`, 'All its expenses will be removed too.', () => deleteCategory(cat.id));
       });
     });
 
     return card;
-  }
-
-  function renderSub(cat, sub) {
-    const spent = subSpent(sub);
-    const limit = +sub.limit || 0;
-    const pct = limit > 0 ? (spent / limit) * 100 : 0;
-    const over = spent > limit && limit > 0;
-    const warn = !over && pct >= 80;
-
-    const el = document.createElement('div');
-    el.className = 'sub';
-    const ro = isReadOnly();
-    el.innerHTML = `
-      <div class="sub-head">
-        <div>
-          <div class="sub-name"></div>
-          <div class="sub-amounts"></div>
-        </div>
-        <div class="sub-actions">
-          ${ro ? '' : `
-            <button data-act="add">+ exp</button>
-            <button data-act="del">×</button>
-          `}
-        </div>
-      </div>
-      <div class="bar ${over ? 'over' : warn ? 'warn' : ''}">
-        <div class="bar-fill" style="width: ${Math.min(pct, 100)}%"></div>
-      </div>
-    `;
-    el.querySelector('.sub-name').textContent = sub.name;
-    el.querySelector('.sub-amounts').textContent =
-      `${fmt(spent)} / ${fmt(limit)} · ${Math.round(pct)}%${over ? ' · OVER ' + fmt(spent - limit) : ''}`;
-
-    el.querySelectorAll('.sub-actions button').forEach(b => {
-      b.addEventListener('click', () => {
-        if (b.dataset.act === 'add') openExpenseModal(cat.id, sub.id);
-        else if (b.dataset.act === 'del') confirmDelete(`Delete sub-budget "${sub.name}"?`, 'Its expenses will be removed.', () => deleteSub(cat.id, sub.id));
-      });
-    });
-    return el;
   }
 
   // ---------- Mutations ----------
@@ -382,7 +339,7 @@ import { firebaseConfig } from './firebase-config.js';
     const m = getMonth();
     m.categories.push({
       id: uid(), name, limit: +limit, color, icon,
-      expenses: [], subs: []
+      expenses: []
     });
     save();
     render();
@@ -407,21 +364,13 @@ import { firebaseConfig } from './firebase-config.js';
     if (cat) toast(`Removed "${cat.name}"`, 'info');
   }
 
-  function addExpense(categoryId, subId, name, amount) {
+  function addExpense(categoryId, name, amount) {
     if (isReadOnly()) return;
     const m = getMonth();
     const cat = m.categories.find(c => c.id === categoryId);
     if (!cat) return;
-    const expense = { id: uid(), name, amount: +amount };
-    if (subId) {
-      const sub = (cat.subs || []).find(s => s.id === subId);
-      if (!sub) return;
-      sub.expenses = sub.expenses || [];
-      sub.expenses.push(expense);
-    } else {
-      cat.expenses = cat.expenses || [];
-      cat.expenses.push(expense);
-    }
+    cat.expenses = cat.expenses || [];
+    cat.expenses.push({ id: uid(), name, amount: +amount });
     save();
     render();
 
@@ -434,26 +383,6 @@ import { firebaseConfig } from './firebase-config.js';
     } else if (limit > 0 && spent / limit >= 0.8) {
       toast(`Watch out — "${cat.name}" at ${Math.round(spent / limit * 100)}%`, 'info');
     }
-  }
-
-  function addSub(categoryId, name, limit) {
-    if (isReadOnly()) return;
-    const m = getMonth();
-    const cat = m.categories.find(c => c.id === categoryId);
-    if (!cat) return;
-    cat.subs = cat.subs || [];
-    cat.subs.push({ id: uid(), name, limit: +limit, expenses: [] });
-    save();
-    render();
-  }
-
-  function deleteSub(categoryId, subId) {
-    const m = getMonth();
-    const cat = m.categories.find(c => c.id === categoryId);
-    if (!cat) return;
-    cat.subs = (cat.subs || []).filter(s => s.id !== subId);
-    save();
-    render();
   }
 
   function startNewMonth() {
@@ -480,13 +409,7 @@ import { firebaseConfig } from './firebase-config.js';
       limit: c.limit,
       color: c.color,
       icon: c.icon,
-      expenses: [],
-      subs: (c.subs || []).map(s => ({
-        id: uid(),
-        name: s.name,
-        limit: s.limit,
-        expenses: []
-      }))
+      expenses: []
     }));
 
     data.months[key] = { income: [], categories: carriedCategories };
@@ -563,31 +486,17 @@ import { firebaseConfig } from './firebase-config.js';
     });
   }
 
-  function openExpenseModal(categoryId, subId) {
+  function openExpenseModal(categoryId) {
     if (isReadOnly()) return;
-    activeExpenseTarget = { categoryId, subId };
+    activeExpenseTarget = { categoryId };
     const modal = document.getElementById('expense-modal');
     const title = document.getElementById('expense-modal-title');
     const cat = getMonth().categories.find(c => c.id === categoryId);
-    if (subId) {
-      const sub = cat.subs.find(s => s.id === subId);
-      title.textContent = `Add to ${cat.name} › ${sub.name}`;
-    } else {
-      title.textContent = `Add to ${cat.name}`;
-    }
+    title.textContent = `Add to ${cat.name}`;
     document.getElementById('exp-name').value = '';
     document.getElementById('exp-amount').value = '';
     modal.hidden = false;
     setTimeout(() => document.getElementById('exp-name').focus(), 50);
-  }
-
-  function openSubModal(categoryId) {
-    if (isReadOnly()) return;
-    activeSubCategoryId = categoryId;
-    document.getElementById('sub-name').value = '';
-    document.getElementById('sub-limit').value = '';
-    document.getElementById('sub-modal').hidden = false;
-    setTimeout(() => document.getElementById('sub-name').focus(), 50);
   }
 
   function openIncomeModal() {
@@ -895,7 +804,7 @@ import { firebaseConfig } from './firebase-config.js';
       const name = document.getElementById('exp-name').value.trim();
       const amount = +document.getElementById('exp-amount').value;
       if (!name || amount < 0 || !activeExpenseTarget) return;
-      addExpense(activeExpenseTarget.categoryId, activeExpenseTarget.subId, name, amount);
+      addExpense(activeExpenseTarget.categoryId, name, amount);
       activeExpenseTarget = null;
       closeAllModals();
     });
@@ -907,17 +816,6 @@ import { firebaseConfig } from './firebase-config.js';
       const amount = +document.getElementById('inc-amount').value;
       if (!name || amount < 0) return;
       addIncome(name, amount);
-      closeAllModals();
-    });
-
-    // Sub-budget form
-    document.getElementById('sub-form').addEventListener('submit', (e) => {
-      e.preventDefault();
-      const name = document.getElementById('sub-name').value.trim();
-      const limit = +document.getElementById('sub-limit').value;
-      if (!name || limit < 0 || !activeSubCategoryId) return;
-      addSub(activeSubCategoryId, name, limit);
-      activeSubCategoryId = null;
       closeAllModals();
     });
 

--- a/index.html
+++ b/index.html
@@ -171,29 +171,6 @@
     </div>
   </div>
 
-  <!-- Modal: Add Sub-Budget -->
-  <div class="modal" id="sub-modal" hidden>
-    <div class="modal-backdrop" data-close></div>
-    <div class="modal-card">
-      <button class="modal-close" data-close>×</button>
-      <h3>New Sub-Budget</h3>
-      <form id="sub-form">
-        <label>
-          Name
-          <input type="text" id="sub-name" required maxlength="40" placeholder="e.g. Groceries, Eating Out" />
-        </label>
-        <label>
-          Limit ($)
-          <input type="number" id="sub-limit" required min="0" step="0.01" placeholder="200" />
-        </label>
-        <div class="modal-actions">
-          <button type="button" class="ghost-btn" data-close>Cancel</button>
-          <button type="submit" class="primary-btn">Save</button>
-        </div>
-      </form>
-    </div>
-  </div>
-
   <!-- Modal: History -->
   <div class="modal" id="history-modal" hidden>
     <div class="modal-backdrop" data-close></div>

--- a/styles.css
+++ b/styles.css
@@ -39,12 +39,14 @@ html, body {
   min-height: 100vh;
   font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   color: var(--ink);
-  overflow-x: hidden;
-  overscroll-behavior: none;
 }
 
 body {
   background-color: var(--bg-0);
+  /* overflow-x and overscroll-behavior live on body only —
+     putting overflow-x on html breaks vertical scrolling on mobile. */
+  overflow-x: hidden;
+  overscroll-behavior-y: none;
 }
 
 /* Soft warm gradient — no neon, no cosmic glow. */
@@ -471,68 +473,6 @@ main {
   margin-left: 6px;
   letter-spacing: 0.4px;
   font-weight: 700;
-}
-
-/* sub-budgets */
-.subs {
-  margin-top: 14px;
-  padding-top: 14px;
-  border-top: 1px dashed var(--line-strong);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.sub {
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: var(--surface-2);
-  border: 1px solid var(--line);
-  transition: background 0.18s ease, border-color 0.18s ease;
-}
-.sub:hover {
-  background: var(--bg-1);
-  border-color: var(--line-strong);
-}
-.sub-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 6px;
-  gap: 8px;
-}
-.sub-name { font-size: 13px; font-weight: 600; color: var(--ink); }
-.sub-amounts { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; margin-top: 2px; }
-.sub-actions { display: flex; gap: 2px; }
-.sub-actions button {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  font-size: 12px;
-  padding: 3px 8px;
-  border-radius: 6px;
-  transition: all 0.15s ease;
-}
-.sub-actions button:hover { background: var(--surface); color: var(--ink); }
-.sub .bar { height: 6px; }
-
-.cat-add-sub {
-  margin-top: 10px;
-  width: 100%;
-  border: 1px dashed var(--line-strong);
-  background: transparent;
-  color: var(--ink-dim);
-  padding: 8px;
-  border-radius: 10px;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 500;
-  transition: all 0.18s ease;
-}
-.cat-add-sub:hover {
-  border-color: var(--cat-color, var(--accent));
-  color: var(--cat-color, var(--accent));
-  background: color-mix(in srgb, var(--cat-color, var(--accent)) 6%, transparent);
 }
 
 /* expenses list (chips) */


### PR DESCRIPTION
## Summary

Follow-up to #28. Three changes:

- **Light theme** — replaced the deep-purple/neon "space" look with a clean cream/peach palette and indigo/coral/mint accents. Soft shadows instead of glows. Removed the particle constellation canvas, scanline overlay, and multi-color shimmer. Kept the fun bits: pop-in card animations, hover lift, shake-on-overbudget, pulsing red bars, confetti.
- **Mobile scroll fix** — `overflow-x: hidden` and `overscroll-behavior` were on both `html` and `body`, which breaks vertical scrolling on mobile (the sticky topbar's scroll container gets confused). Moved both to `body` only.
- **Sub-categories removed** — dropped the sub-budget modal, rendering, data model, and CSS per request. Categories are now a flat list of expenses. Existing data with sub-budgets gets a one-time migration: sub expenses are flattened into the parent category as `subname: expense_name` so nothing is lost.

App.js shrank from ~970 to ~830 lines.

## Test plan

- [ ] Live Pages URL renders with the new light theme
- [ ] Scroll a long page on mobile — vertical scrolling works, no white flash
- [ ] Add a category, add an expense, confirm progress bar fills & turns red over limit
- [ ] Add income, confetti fires
- [ ] "↻ New Month" carries categories forward with $0 spent
- [ ] History modal shows prior months as read-only snapshots
- [ ] If you had sub-budgets before merging: confirm their expenses now appear under the parent category labeled `subname: expense_name`
- [ ] Firebase sync (if configured): join household on second device, confirm real-time updates

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_