### PR TITLE
Restore document scrolling (real fix)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -36,17 +36,13 @@ html {
 html, body {
   margin: 0;
   padding: 0;
-  min-height: 100vh;
   font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   color: var(--ink);
 }
 
 body {
+  min-height: 100vh;
   background-color: var(--bg-0);
-  /* overflow-x and overscroll-behavior live on body only —
-     putting overflow-x on html breaks vertical scrolling on mobile. */
-  overflow-x: hidden;
-  overscroll-behavior-y: none;
 }
 
 /* Soft warm gradient — no neon, no cosmic glow. */


### PR DESCRIPTION
## Summary

Real fix for the mobile scroll lock that #29 didn't fully solve.

**Root cause:** `body` had `overflow-x: hidden`. Browsers don't allow mixing `visible` overflow on one axis with `hidden` on the other, so they silently promote `overflow-y` from `visible` to `auto`. That turns `body` into its own scroll container instead of the viewport, which combined with `min-height: 100vh` made body exactly viewport-tall — content overflow went *inside* body, but mobile touch-scroll often can't find it. Page felt frozen.

**Fix:** Removed `overflow-x: hidden` and `overscroll-behavior-y: none` from body. Nothing in the layout actually causes horizontal overflow, so the rule wasn't doing useful work. The earlier white-flash issue is still handled cleanly by the fixed gradient `body::before` pseudo-element + solid `html { background-color }` — no overflow trickery needed.

## Test plan

- [ ] On phone, scroll a long page — works smoothly top to bottom
- [ ] On desktop, scroll still works (no regression)
- [ ] No white flash at the bottom on either platform
- [ ] Sticky topbar still sticks to the top of the viewport while scrolling

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_