### PR TITLE
Unlock or delete historical months

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,7 +163,7 @@ import { firebaseConfig } from './firebase-config.js';
     const isCurrent = key === data.currentMonth;
     document.getElementById('reset-month').hidden = !isCurrent;
     document.getElementById('unlock-month').hidden = isCurrent;
-    document.getElementById('delete-month').hidden = isCurrent;
+    document.getElementById('clear-month').hidden = isCurrent;
 
     // Disable add buttons when read-only
     const ro = isReadOnly();
@@ -439,17 +439,20 @@ import { firebaseConfig } from './firebase-config.js';
   }
 
   /**
-   * Delete the currently-viewed historical month entirely. The active month
-   * can never be deleted — that would wipe live data without warning.
+   * Reset the currently-viewed historical month: drop income and all
+   * expenses, but keep the month entry and its category definitions.
+   * Useful for cleaning up an accidental "New Month" without losing the
+   * structure of categories you already set up.
    */
-  function deleteHistoricalMonth() {
+  function clearHistoricalMonth() {
     if (!viewingMonth || viewingMonth === data.currentMonth) return;
-    const key = viewingMonth;
-    delete data.months[key];
-    viewingMonth = null;
+    const m = data.months[viewingMonth];
+    if (!m) return;
+    m.income = [];
+    (m.categories || []).forEach(c => { c.expenses = []; });
     save();
     render();
-    toast(`Deleted ${monthLabel(key)}`, 'info');
+    toast(`Cleared ${monthLabel(viewingMonth)}`, 'info');
   }
 
   // ---------- Modals ----------
@@ -799,10 +802,10 @@ import { firebaseConfig } from './firebase-config.js';
       confirmDelete('Start a new month?', 'This locks in the current month as history and starts fresh. Your categories carry over with $0 spent.', startNewMonth);
     });
     document.getElementById('unlock-month').addEventListener('click', reactivateMonth);
-    document.getElementById('delete-month').addEventListener('click', () => {
+    document.getElementById('clear-month').addEventListener('click', () => {
       if (!viewingMonth || viewingMonth === data.currentMonth) return;
       const label = monthLabel(viewingMonth);
-      confirmDelete(`Delete ${label}?`, 'This permanently removes this month’s record. The active month is unaffected.', deleteHistoricalMonth);
+      confirmDelete(`Clear ${label}?`, 'Income and all expenses for this month will be reset to zero. Your categories stay.', clearHistoricalMonth);
     });
     document.getElementById('history-btn').addEventListener('click', openHistoryModal);
 

--- a/app.js
+++ b/app.js
@@ -160,9 +160,10 @@ import { firebaseConfig } from './firebase-config.js';
       status.textContent = 'Viewing';
     }
 
-    const resetBtn = document.getElementById('reset-month');
     const isCurrent = key === data.currentMonth;
-    resetBtn.style.display = isCurrent ? '' : 'none';
+    document.getElementById('reset-month').hidden = !isCurrent;
+    document.getElementById('unlock-month').hidden = isCurrent;
+    document.getElementById('delete-month').hidden = isCurrent;
 
     // Disable add buttons when read-only
     const ro = isReadOnly();
@@ -419,6 +420,36 @@ import { firebaseConfig } from './firebase-config.js';
     render();
     fireConfetti();
     toast(`New month started: ${monthLabel(key)} 🚀`, 'success');
+  }
+
+  /**
+   * Make the currently-viewed historical month active again.
+   * The previously-active month becomes a regular historical entry — it isn't
+   * deleted, so nothing is destroyed by mistake. The user can then delete it
+   * separately if it was an empty/accidental month.
+   */
+  function reactivateMonth() {
+    if (!viewingMonth || viewingMonth === data.currentMonth) return;
+    const newActive = viewingMonth;
+    data.currentMonth = newActive;
+    viewingMonth = null;
+    save();
+    render();
+    toast(`${monthLabel(newActive)} is active again 🔓`, 'success');
+  }
+
+  /**
+   * Delete the currently-viewed historical month entirely. The active month
+   * can never be deleted — that would wipe live data without warning.
+   */
+  function deleteHistoricalMonth() {
+    if (!viewingMonth || viewingMonth === data.currentMonth) return;
+    const key = viewingMonth;
+    delete data.months[key];
+    viewingMonth = null;
+    save();
+    render();
+    toast(`Deleted ${monthLabel(key)}`, 'info');
   }
 
   // ---------- Modals ----------
@@ -766,6 +797,12 @@ import { firebaseConfig } from './firebase-config.js';
     });
     document.getElementById('reset-month').addEventListener('click', () => {
       confirmDelete('Start a new month?', 'This locks in the current month as history and starts fresh. Your categories carry over with $0 spent.', startNewMonth);
+    });
+    document.getElementById('unlock-month').addEventListener('click', reactivateMonth);
+    document.getElementById('delete-month').addEventListener('click', () => {
+      if (!viewingMonth || viewingMonth === data.currentMonth) return;
+      const label = monthLabel(viewingMonth);
+      confirmDelete(`Delete ${label}?`, 'This permanently removes this month’s record. The active month is unaffected.', deleteHistoricalMonth);
     });
     document.getElementById('history-btn').addEventListener('click', openHistoryModal);
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
       </div>
       <button id="next-month" class="icon-btn" title="Next month">›</button>
       <button id="reset-month" class="ghost-btn" title="Start a new month">↻ New Month</button>
+      <button id="unlock-month" class="ghost-btn" title="Make this month active again" hidden>🔓 Make Active</button>
+      <button id="delete-month" class="ghost-btn delete-btn" title="Delete this month" hidden>🗑 Delete</button>
       <button id="history-btn" class="ghost-btn" title="View previous months">📜 History</button>
       <button id="sync-indicator" class="sync-indicator local" title="Sync settings">
         <span class="sync-dot"></span>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <button id="next-month" class="icon-btn" title="Next month">›</button>
       <button id="reset-month" class="ghost-btn" title="Start a new month">↻ New Month</button>
       <button id="unlock-month" class="ghost-btn" title="Make this month active again" hidden>🔓 Make Active</button>
-      <button id="delete-month" class="ghost-btn delete-btn" title="Delete this month" hidden>🗑 Delete</button>
+      <button id="clear-month" class="ghost-btn delete-btn" title="Reset this month's income and expenses" hidden>🧹 Clear</button>
       <button id="history-btn" class="ghost-btn" title="View previous months">📜 History</button>
       <button id="sync-indicator" class="sync-indicator local" title="Sync settings">
         <span class="sync-dot"></span>

--- a/styles.css
+++ b/styles.css
@@ -188,6 +188,12 @@ main {
   transform: translateY(-1px);
 }
 
+.ghost-btn.delete-btn:hover {
+  background: color-mix(in srgb, var(--bad) 8%, white);
+  border-color: color-mix(in srgb, var(--bad) 35%, transparent);
+  color: var(--bad);
+}
+
 .primary-btn {
   border: none;
   background: var(--accent);


### PR DESCRIPTION
## Summary

Two new buttons appear in the header **only when viewing a past (non-active) month**:

- **🔓 Make Active** — promotes the historical month back to active status. The previously-active month becomes a regular historical entry (it isn't destroyed, so you can switch back). This is the "undo accidental New Month" path.
- **🗑 Delete** — permanently removes the viewed historical month, with a confirm dialog. Useful for cleaning up an empty mistake-month after reactivating the real one. The active month can never be deleted.

## Typical recovery flow

1. You accidentally click "↻ New Month" mid-month
2. Use the `‹` arrow (or History modal) to navigate back to the prior month
3. Click **🔓 Make Active** — old month is live again
4. Navigate forward to the empty new month → **🗑 Delete** to clean it up

## Test plan

- [ ] On an active month, neither new button is visible
- [ ] On a historical month, both buttons appear
- [ ] Make Active swaps the active state and clears the read-only banner
- [ ] Delete shows a confirm dialog and removes the month from history
- [ ] You can't delete the active month (button hidden)
- [ ] Sync (if configured): unlock/delete propagates to the partner's device

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_