### PR TITLE
Apple/Material-style header redesign + UI polish

### DIFF
--- a/app.js
+++ b/app.js
@@ -152,15 +152,12 @@ import { firebaseConfig } from './firebase-config.js';
 
   function renderHeader() {
     const key = activeMonth();
+    const isCurrent = key === data.currentMonth;
     document.getElementById('month-name').textContent = monthLabel(key);
     const status = document.getElementById('month-status');
-    if (key === data.currentMonth) {
-      status.textContent = 'Active';
-    } else {
-      status.textContent = 'Viewing';
-    }
+    status.textContent = isCurrent ? 'Active' : 'Viewing';
+    status.classList.toggle('viewing', !isCurrent);
 
-    const isCurrent = key === data.currentMonth;
     document.getElementById('reset-month').hidden = !isCurrent;
     document.getElementById('unlock-month').hidden = isCurrent;
     document.getElementById('clear-month').hidden = isCurrent;

--- a/index.html
+++ b/index.html
@@ -11,28 +11,47 @@
   <div id="confetti-layer" aria-hidden="true"></div>
 
   <header class="topbar">
-    <div class="brand">
-      <span class="logo">💰</span>
-      <div class="brand-text">
+    <div class="topbar-row topbar-row-top">
+      <div class="brand">
+        <span class="logo">💰</span>
         <h1>Budget Quest</h1>
-        <p class="tagline">Level up your money</p>
       </div>
-    </div>
-    <div class="month-switcher">
-      <button id="prev-month" class="icon-btn" title="Previous month">‹</button>
-      <div class="month-label">
-        <span id="month-name">—</span>
-        <small id="month-status"></small>
-      </div>
-      <button id="next-month" class="icon-btn" title="Next month">›</button>
-      <button id="reset-month" class="ghost-btn" title="Start a new month">↻ New Month</button>
-      <button id="unlock-month" class="ghost-btn" title="Make this month active again" hidden>🔓 Make Active</button>
-      <button id="clear-month" class="ghost-btn delete-btn" title="Reset this month's income and expenses" hidden>🧹 Clear</button>
-      <button id="history-btn" class="ghost-btn" title="View previous months">📜 History</button>
       <button id="sync-indicator" class="sync-indicator local" title="Sync settings">
         <span class="sync-dot"></span>
         <span class="sync-label">Local</span>
       </button>
+    </div>
+    <div class="topbar-row topbar-row-bottom">
+      <div class="month-picker">
+        <button id="prev-month" class="month-arrow" title="Previous month" aria-label="Previous month">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        </button>
+        <div class="month-display">
+          <span id="month-name" class="month-name">—</span>
+          <span id="month-status" class="month-status"></span>
+        </div>
+        <button id="next-month" class="month-arrow" title="Next month" aria-label="Next month">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+        </button>
+      </div>
+      <div class="topbar-actions">
+        <button id="reset-month" class="pill-btn" title="Start a new month">
+          <span class="pill-icon">↻</span>
+          <span class="pill-label">New Month</span>
+        </button>
+        <button id="unlock-month" class="pill-btn pill-accent" title="Make this month active again" hidden>
+          <span class="pill-icon">🔓</span>
+          <span class="pill-label">Make Active</span>
+        </button>
+        <button id="clear-month" class="pill-btn pill-danger" title="Reset this month's income and expenses" hidden>
+          <span class="pill-icon">🧹</span>
+          <span class="pill-label">Clear</span>
+        </button>
+        <button id="history-btn" class="pill-btn" title="View previous months">
+          <span class="pill-icon">📜</span>
+          <span class="pill-label">History</span>
+        </button>
+      </div>
     </div>
   </header>
 

--- a/styles.css
+++ b/styles.css
@@ -21,10 +21,10 @@
   --good: #10b981;        /* emerald */
   --warn: #f59e0b;        /* amber */
   --bad: #ef4444;         /* red */
-  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 3px rgba(15, 23, 42, 0.06);
-  --shadow: 0 4px 12px rgba(15, 23, 42, 0.06), 0 2px 4px rgba(15, 23, 42, 0.04);
-  --shadow-lg: 0 12px 32px rgba(15, 23, 42, 0.10), 0 4px 8px rgba(15, 23, 42, 0.06);
-  --radius: 14px;
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 3px rgba(15, 23, 42, 0.05);
+  --shadow: 0 6px 18px rgba(15, 23, 42, 0.07), 0 1px 3px rgba(15, 23, 42, 0.04);
+  --shadow-lg: 0 16px 40px rgba(15, 23, 42, 0.12), 0 4px 10px rgba(15, 23, 42, 0.06);
+  --radius: 16px;
 }
 
 * { box-sizing: border-box; }
@@ -74,85 +74,173 @@ main {
   padding: 24px 24px 80px;
 }
 
-/* ---------- Top bar ---------- */
+/* ---------- Top bar (Apple/Material-inspired) ---------- */
 .topbar {
   position: sticky;
   top: 0;
   z-index: 10;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px 24px;
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 24px 16px;
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
   border-bottom: 1px solid var(--line);
 }
 
-.brand {
+.topbar-row {
   display: flex;
   align-items: center;
   gap: 12px;
 }
 
+.topbar-row-top {
+  justify-content: space-between;
+}
+
+.topbar-row-bottom {
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .logo {
-  font-size: 28px;
+  font-size: 24px;
   animation: float 4s ease-in-out infinite;
 }
 
-.brand-text h1 {
+.brand h1 {
   margin: 0;
-  font-size: 22px;
+  font-size: 19px;
   font-weight: 700;
-  background: linear-gradient(135deg, var(--accent), var(--accent-2));
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  letter-spacing: -0.3px;
-}
-
-.brand-text .tagline {
-  margin: 2px 0 0;
-  font-size: 11px;
-  letter-spacing: 1.5px;
-  text-transform: uppercase;
-  color: var(--muted);
-  font-weight: 500;
-}
-
-.month-switcher {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.month-label {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  min-width: 140px;
-  padding: 6px 14px;
-  border-radius: 10px;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  box-shadow: var(--shadow-sm);
-}
-
-.month-label span {
-  font-weight: 600;
-  font-size: 14px;
+  letter-spacing: -0.4px;
   color: var(--ink);
 }
 
-.month-label small {
-  font-size: 10px;
-  color: var(--muted);
-  letter-spacing: 1.5px;
-  text-transform: uppercase;
-  font-weight: 600;
+/* ---------- Month picker (segmented pill) ---------- */
+.month-picker {
+  display: inline-flex;
+  align-items: stretch;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px;
+  box-shadow: var(--shadow-sm);
 }
 
+.month-arrow {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--ink-dim);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.12s ease;
+}
+.month-arrow:hover {
+  background: var(--bg-1);
+  color: var(--ink);
+}
+.month-arrow:active { transform: scale(0.92); }
+.month-arrow svg { display: block; }
+
+.month-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0 14px;
+  min-width: 130px;
+}
+
+.month-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -0.1px;
+  font-variant-numeric: tabular-nums;
+}
+
+.month-status {
+  font-size: 9.5px;
+  color: var(--accent);
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-top: 1px;
+}
+
+.month-status.viewing {
+  color: var(--warn);
+}
+
+/* ---------- Pill action buttons ---------- */
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.pill-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px 8px 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.1px;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background 0.18s ease,
+              border-color 0.18s ease,
+              box-shadow 0.18s ease,
+              color 0.18s ease;
+}
+.pill-btn:hover {
+  background: var(--bg-1);
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+.pill-btn:active { transform: scale(0.96); }
+
+.pill-btn .pill-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.pill-btn.pill-accent {
+  background: color-mix(in srgb, var(--accent) 10%, white);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  color: var(--accent);
+}
+.pill-btn.pill-accent:hover {
+  background: color-mix(in srgb, var(--accent) 16%, white);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.pill-btn.pill-danger:hover {
+  background: color-mix(in srgb, var(--bad) 9%, white);
+  border-color: color-mix(in srgb, var(--bad) 40%, transparent);
+  color: var(--bad);
+}
+
+/* ---------- Generic button styles (modals, etc) ---------- */
 .icon-btn {
   width: 36px; height: 36px;
   border-radius: 10px;
@@ -169,24 +257,28 @@ main {
   background: var(--bg-1);
   border-color: var(--line-strong);
 }
+.icon-btn:active { transform: scale(0.94); }
 
 .ghost-btn {
   border: 1px solid var(--line);
   background: var(--surface);
   color: var(--ink);
-  padding: 8px 14px;
-  border-radius: 10px;
+  padding: 9px 16px;
+  border-radius: 999px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
+  letter-spacing: -0.1px;
   cursor: pointer;
   box-shadow: var(--shadow-sm);
-  transition: all 0.18s ease;
+  transition: transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 }
 .ghost-btn:hover {
   background: var(--bg-1);
   border-color: var(--line-strong);
   transform: translateY(-1px);
 }
+.ghost-btn:active { transform: scale(0.96); }
 
 .ghost-btn.delete-btn:hover {
   background: color-mix(in srgb, var(--bad) 8%, white);
@@ -198,32 +290,37 @@ main {
   border: none;
   background: var(--accent);
   color: #fff;
-  padding: 9px 16px;
-  border-radius: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
   font-size: 13px;
   font-weight: 600;
+  letter-spacing: -0.05px;
   cursor: pointer;
-  letter-spacing: 0.2px;
-  box-shadow: 0 2px 6px rgba(99, 102, 241, 0.3);
-  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.28),
+              0 1px 2px rgba(99, 102, 241, 0.2);
+  transition: transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1),
+              box-shadow 0.2s ease, background 0.2s ease;
 }
 .primary-btn:hover {
   transform: translateY(-1px);
   background: #4f52ef;
-  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.4);
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.36),
+              0 1px 2px rgba(99, 102, 241, 0.2);
 }
-.primary-btn:active { transform: translateY(0); }
+.primary-btn:active { transform: scale(0.96); }
 
 .danger-btn {
   border: none;
   background: var(--bad);
   color: #fff;
-  padding: 9px 16px;
-  border-radius: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
   font-weight: 600;
+  font-size: 13px;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgba(239, 68, 68, 0.3);
-  transition: transform 0.15s ease;
+  box-shadow: 0 4px 14px rgba(239, 68, 68, 0.28),
+              0 1px 2px rgba(239, 68, 68, 0.2);
+  transition: transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 .danger-btn:hover { transform: translateY(-1px); background: #dc2626; }
 
@@ -239,16 +336,19 @@ main {
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 18px;
-  border-radius: var(--radius);
+  padding: 20px;
+  border-radius: 18px;
   background: var(--surface);
   border: 1px solid var(--line);
   box-shadow: var(--shadow);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.25s cubic-bezier(0.34, 1.4, 0.64, 1),
+              box-shadow 0.25s ease,
+              border-color 0.2s ease;
 }
 .stat-card:hover {
-  transform: translateY(-2px);
+  transform: translateY(-3px);
   box-shadow: var(--shadow-lg);
+  border-color: var(--line-strong);
 }
 .stat-income    { --card-glow: var(--good); }
 .stat-budget    { --card-glow: var(--accent); }
@@ -256,46 +356,49 @@ main {
 .stat-remaining { --card-glow: var(--accent-2); }
 
 .stat-icon {
-  font-size: 24px;
-  width: 48px; height: 48px;
+  font-size: 22px;
+  width: 46px; height: 46px;
   display: grid; place-items: center;
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--card-glow) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--card-glow) 25%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--card-glow) 14%, white);
+  border: 1px solid color-mix(in srgb, var(--card-glow) 22%, transparent);
+  flex-shrink: 0;
 }
 
-.stat-body { display: flex; flex-direction: column; }
+.stat-body { display: flex; flex-direction: column; min-width: 0; }
 .stat-label {
-  font-size: 11px;
-  letter-spacing: 1.2px;
+  font-size: 10.5px;
+  letter-spacing: 1px;
   text-transform: uppercase;
   color: var(--muted);
-  font-weight: 600;
+  font-weight: 700;
 }
 .stat-value {
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 700;
-  margin-top: 2px;
+  margin-top: 4px;
   font-variant-numeric: tabular-nums;
   color: var(--ink);
+  letter-spacing: -0.5px;
+  line-height: 1.1;
 }
 
 /* ---------- Sections ---------- */
 .section {
-  margin-bottom: 32px;
+  margin-bottom: 36px;
 }
 .section-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 14px;
+  margin-bottom: 16px;
 }
 .section-header h2 {
   margin: 0;
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
   color: var(--ink);
-  letter-spacing: -0.2px;
+  letter-spacing: -0.4px;
 }
 
 /* ---------- Income list ---------- */
@@ -352,14 +455,16 @@ main {
 
 .category-card {
   position: relative;
-  padding: 18px;
-  border-radius: var(--radius);
+  padding: 20px;
+  border-radius: 18px;
   background: var(--surface);
   border: 1px solid var(--line);
   box-shadow: var(--shadow);
   overflow: hidden;
-  animation: pop-in 0.35s ease backwards;
-  transition: transform 0.2s ease, box-shadow 0.25s ease;
+  animation: pop-in 0.4s cubic-bezier(0.34, 1.4, 0.64, 1) backwards;
+  transition: transform 0.25s cubic-bezier(0.34, 1.4, 0.64, 1),
+              box-shadow 0.25s ease,
+              border-color 0.2s ease;
 }
 .category-card::before {
   content: '';
@@ -369,8 +474,9 @@ main {
   background: var(--cat-color, var(--accent));
 }
 .category-card:hover {
-  transform: translateY(-2px);
+  transform: translateY(-3px);
   box-shadow: var(--shadow-lg);
+  border-color: var(--line-strong);
 }
 .category-card.over {
   animation: pop-in 0.35s ease backwards, shake 0.6s ease;
@@ -532,19 +638,21 @@ main {
   width: 100%;
   max-width: 440px;
   padding: 28px;
-  border-radius: 18px;
+  border-radius: 22px;
   background: var(--surface);
   border: 1px solid var(--line);
-  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.18);
-  animation: zoom-in 0.22s cubic-bezier(0.34, 1.4, 0.64, 1);
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.22),
+              0 4px 12px rgba(15, 23, 42, 0.08);
+  animation: zoom-in 0.28s cubic-bezier(0.34, 1.5, 0.64, 1);
 }
 .modal-wide { max-width: 700px; }
 .modal-narrow { max-width: 360px; }
 .modal-card h3 {
   margin: 0 0 18px;
   color: var(--ink);
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
+  letter-spacing: -0.4px;
 }
 .modal-close {
   position: absolute;
@@ -575,12 +683,13 @@ main {
   display: block;
   width: 100%;
   margin-top: 6px;
-  padding: 10px 12px;
+  padding: 12px 14px;
   background: var(--bg-1);
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: 12px;
   color: var(--ink);
-  font-size: 14px;
+  font-size: 15px;
+  font-weight: 500;
   font-family: inherit;
   transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
 }
@@ -588,7 +697,7 @@ main {
   outline: none;
   background: var(--surface);
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
 .emoji-grid, .color-grid {
@@ -700,24 +809,32 @@ main {
 .sync-indicator {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 12px;
+  gap: 7px;
+  padding: 6px 12px 6px 10px;
   border-radius: 999px;
   border: 1px solid var(--line);
   background: var(--surface);
   color: var(--ink-dim);
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.2px;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: -0.05px;
   cursor: pointer;
   box-shadow: var(--shadow-sm);
-  transition: all 0.18s ease;
+  transition: transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
-.sync-indicator:hover { background: var(--bg-1); color: var(--ink); }
+.sync-indicator:hover {
+  background: var(--bg-1);
+  color: var(--ink);
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+}
+.sync-indicator:active { transform: scale(0.96); }
 .sync-indicator .sync-dot {
-  width: 8px; height: 8px;
+  width: 7px; height: 7px;
   border-radius: 50%;
   background: var(--muted);
+  flex-shrink: 0;
 }
 .sync-indicator.synced     .sync-dot { background: var(--good); animation: pulse-dot 2.4s ease-in-out infinite; }
 .sync-indicator.syncing    .sync-dot { background: var(--accent); animation: pulse-dot 0.9s ease-in-out infinite; }
@@ -853,15 +970,24 @@ main {
 
 /* ---------- Responsive ---------- */
 @media (max-width: 800px) {
-  .topbar { flex-direction: column; align-items: stretch; gap: 12px; padding: 14px; }
-  .month-switcher { justify-content: center; flex-wrap: wrap; }
+  .topbar { padding: 12px 14px 14px; }
+  .topbar-row-bottom { justify-content: center; }
+  .topbar-actions { justify-content: center; flex: 1 1 auto; }
   .dashboard { grid-template-columns: repeat(2, 1fr); }
   .stat-value { font-size: 18px; }
   main { padding: 16px 14px 60px; }
 }
 @media (max-width: 480px) {
   .dashboard { grid-template-columns: 1fr 1fr; }
-  .brand-text h1 { font-size: 18px; }
+  .brand h1 { font-size: 17px; }
+  .month-display { min-width: 110px; padding: 0 10px; }
+  .month-name { font-size: 13px; }
+  .pill-btn { padding: 7px 12px 7px 11px; font-size: 12.5px; }
+  .pill-btn .pill-label { display: none; }
+  .pill-btn .pill-icon { font-size: 15px; }
+  /* Show label only for the most important action */
+  #reset-month .pill-label,
+  #unlock-month .pill-label { display: inline; }
 }
 
 /* Reduce motion */


### PR DESCRIPTION
## Summary

Header redesign + site-wide polish to match the look of the latest Apple / Google apps.

### Header

**Before:** single row jamming brand + chevrons + month label + 4–5 ghost buttons + sync pill, wrapping awkwardly when "Make Active" + "Clear" were visible.

**After:** clean two-row layout:
- **Top row:** brand on the left, sync indicator on the right
- **Bottom row:** segmented month picker on the left (chevron arrows are circular hit areas inside a single pill), action pills on the right

The month picker is now a real segmented control — SVG chevrons, tabular-num month name, uppercase status badge that turns amber when viewing a past month.

### Buttons

- Pill-shaped (`border-radius: 999px`), Apple-style padding
- Springy press animation (`cubic-bezier(0.34, 1.56, 0.64, 1)` + `:active { scale(0.96) }`)
- Tonal variants: `.pill-accent` (indigo tint) for primary actions, `.pill-danger` (red tint on hover) for destructive
- Consistent sizing across primary / ghost / danger / pill

### Cards & typography

- Larger corner radius (18–22px) and softer multi-layer shadows for depth
- Tighter letter-spacing on headings and numerical values (`-0.4px` to `-0.5px`)
- Larger stat values (24px) and section headers (20px)
- Modal inputs feel more Apple-style: 12px radius, larger padding, 4px focus ring

### Responsive

- On narrow screens (<480px), most pill buttons collapse to icon-only
- "New Month" / "Make Active" keep their labels (they're the most important actions)
- Two-row header continues to look balanced on mobile

## Test plan

- [ ] Header looks balanced on desktop, doesn't wrap weirdly
- [ ] Header collapses to icon-only pills on phone width
- [ ] Month picker arrows show subtle hover background, scale slightly on press
- [ ] Action pills feel "springy" on press
- [ ] Sync indicator pill works the same as before, just looks more refined
- [ ] All existing flows (add category, expense, income, new month, history, sync) still work
- [ ] No console errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_