### PR TITLE
Remove tap-highlight rectangle and click focus square

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -27,7 +27,32 @@
   --radius: 16px;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+  /* Suppress the gray rectangle mobile browsers paint on tap. We rely on
+     custom :active scale animations for press feedback instead. */
+  -webkit-tap-highlight-color: transparent;
+}
+
+button {
+  user-select: none;
+  -webkit-user-select: none;
+  font-family: inherit;
+}
+
+/* Drop the default click outline (it's the ugly square users see), but
+   restore proper keyboard-focus rings via :focus-visible so accessibility
+   is preserved for users navigating with Tab. */
+button:focus,
+[role="button"]:focus,
+a:focus { outline: none; }
+
+button:focus-visible,
+[role="button"]:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 html {
   background-color: var(--bg-0);


### PR DESCRIPTION
## Summary

Removes the gray rectangle / square outline that appeared over the entire pill when you clicked or tapped a button.

**Two things were causing it:**
1. **`-webkit-tap-highlight-color`** — mobile browsers' default behavior of painting a translucent gray box on tap. Set to `transparent` globally.
2. **Default `:focus` outline** — the browser's click-focus ring that the user was seeing as the "ugly square."

**Accessibility preserved:** keyboard-focus rings still appear via `:focus-visible`, so Tab-navigation users still see exactly where focus is. Only mouse and touch interactions lose the outline (which is the correct, modern behavior).

The custom `:active { scale(0.96) }` springy press animation already in place is now the only press feedback — feels tactile and premium, the way native iOS / Material You apps do it.

## Test plan

- [ ] Tap a pill button on mobile — no gray rectangle appears
- [ ] Click a pill button on desktop — no square outline, just the springy scale-down
- [ ] Tab through buttons with the keyboard — accessible focus ring still appears
- [ ] All other interactions still work normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_