### PR TITLE
Make Budget Quest installable as a PWA (Add to Home Screen)

### DIFF
--- a/app.js
+++ b/app.js
@@ -921,12 +921,74 @@ import { firebaseConfig } from './firebase-config.js';
     });
   }
 
+  // ---------- PWA install + offline ----------
+  let deferredInstall = null;
+
+  function isStandalone() {
+    return window.matchMedia('(display-mode: standalone)').matches
+      || window.navigator.standalone === true;
+  }
+
+  function isIosSafari() {
+    const ua = navigator.userAgent;
+    const ios = /iPad|iPhone|iPod/.test(ua) && !window.MSStream;
+    const safari = /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua);
+    return ios && safari;
+  }
+
+  function setupPWA() {
+    // Register the service worker (offline + install eligibility).
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('./service-worker.js').catch((err) => {
+        console.warn('Service worker registration failed', err);
+      });
+    }
+
+    // Don't offer install if already running as an installed app.
+    if (isStandalone()) return;
+
+    const installBtn = document.getElementById('install-btn');
+
+    // Chrome / Edge / Android: capture the prompt event, show our button.
+    window.addEventListener('beforeinstallprompt', (e) => {
+      e.preventDefault();
+      deferredInstall = e;
+      installBtn.hidden = false;
+    });
+
+    // iOS Safari has no beforeinstallprompt — show the button so we can
+    // open a friendly instructions modal when tapped.
+    if (isIosSafari()) installBtn.hidden = false;
+
+    installBtn.addEventListener('click', async () => {
+      if (deferredInstall) {
+        deferredInstall.prompt();
+        const { outcome } = await deferredInstall.userChoice;
+        deferredInstall = null;
+        installBtn.hidden = true;
+        if (outcome === 'accepted') {
+          fireConfetti();
+          toast('Installed! 🎉', 'success');
+        }
+      } else {
+        document.getElementById('install-modal').hidden = false;
+      }
+    });
+
+    window.addEventListener('appinstalled', () => {
+      installBtn.hidden = true;
+      deferredInstall = null;
+      toast('Installed! 🎉', 'success');
+    });
+  }
+
   // ---------- Boot ----------
   function boot() {
     bindEvents();
     render();
     setSyncStatus('local');
     startSync();
+    setupPWA();
   }
 
   if (document.readyState === 'loading') {

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -15,10 +15,11 @@
 // comes from the Firestore rules and authorized domains, not from hiding the keys.
 
 export const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_PROJECT.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_PROJECT.appspot.com",
-  messagingSenderId: "YOUR_SENDER_ID",
-  appId: "YOUR_APP_ID"
+  apiKey: "AIzaSyDrSP0gKhZRzerj5RyxtDMbHkKzW5wVT0M",
+  authDomain: "budget-quest-ac4be.firebaseapp.com",
+  projectId: "budget-quest-ac4be",
+  storageBucket: "budget-quest-ac4be.firebasestorage.app",
+  messagingSenderId: "150257518386",
+  appId: "1:150257518386:web:a5b5a32f004f9c89caf92b",
+  measurementId: "G-VZT7GC0Z3B"
 };

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#f43f5e"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)"/>
+  <text x="256" y="368" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, sans-serif" font-size="320" font-weight="800" fill="#ffffff" letter-spacing="-12">$</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Budget Quest — Track. Slay. Save.</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%92%B0%3C/text%3E%3C/svg%3E" />
+  <link rel="manifest" href="manifest.webmanifest" />
+  <meta name="theme-color" content="#6366f1" />
+  <link rel="apple-touch-icon" href="icon.svg" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="apple-mobile-web-app-title" content="Budget Quest" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -16,10 +22,16 @@
         <span class="logo">💰</span>
         <h1>Budget Quest</h1>
       </div>
-      <button id="sync-indicator" class="sync-indicator local" title="Sync settings">
-        <span class="sync-dot"></span>
-        <span class="sync-label">Local</span>
-      </button>
+      <div class="topbar-top-right">
+        <button id="install-btn" class="pill-btn pill-accent" title="Install Budget Quest as an app" hidden>
+          <span class="pill-icon">📱</span>
+          <span class="pill-label">Install</span>
+        </button>
+        <button id="sync-indicator" class="sync-indicator local" title="Sync settings">
+          <span class="sync-dot"></span>
+          <span class="sync-label">Local</span>
+        </button>
+      </div>
     </div>
     <div class="topbar-row topbar-row-bottom">
       <div class="month-picker">
@@ -268,6 +280,24 @@
       <div class="modal-actions">
         <button type="button" class="ghost-btn" id="sync-disconnect-btn">Disconnect (use locally)</button>
         <button type="button" class="primary-btn" id="sync-change-btn">Change household</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: iOS install instructions -->
+  <div class="modal" id="install-modal" hidden>
+    <div class="modal-backdrop" data-close></div>
+    <div class="modal-card">
+      <button class="modal-close" data-close>×</button>
+      <h3>📱 Add to Home Screen</h3>
+      <p class="muted">Install Budget Quest as an app on your phone — full-screen, fast launch, works offline.</p>
+      <ol class="install-steps">
+        <li>Tap the <strong>Share</strong> button at the bottom of Safari</li>
+        <li>Scroll and tap <strong>Add to Home Screen</strong></li>
+        <li>Tap <strong>Add</strong> in the top right</li>
+      </ol>
+      <div class="modal-actions">
+        <button type="button" class="primary-btn" data-close>Got it</button>
       </div>
     </div>
   </div>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Budget Quest",
+  "short_name": "Budget",
+  "description": "A clean budget tracker with monthly resets, history, and household sync.",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#fefaf6",
+  "theme_color": "#6366f1",
+  "icons": [
+    {
+      "src": "icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,60 @@
+/* Budget Quest service worker
+ *
+ * Strategy: stale-while-revalidate for same-origin assets so the app loads
+ * instantly from cache and updates in the background. Firebase, Google,
+ * and gstatic requests pass through untouched (they have their own caching
+ * and need fresh tokens).
+ */
+
+const CACHE = 'budget-quest-v2';
+const ASSETS = [
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './sync.js',
+  './firebase-config.js',
+  './manifest.webmanifest',
+  './icon.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE)
+      .then((cache) => cache.addAll(ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+
+  const url = new URL(req.url);
+
+  // Skip cross-origin requests (Firebase SDK from gstatic, Firestore APIs, etc.)
+  if (url.origin !== self.location.origin) return;
+
+  event.respondWith(
+    caches.match(req).then((cached) => {
+      const networkFetch = fetch(req)
+        .then((res) => {
+          if (res && res.ok) {
+            const copy = res.clone();
+            caches.open(CACHE).then((cache) => cache.put(req, copy));
+          }
+          return res;
+        })
+        .catch(() => cached);
+      return cached || networkFetch;
+    })
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -124,6 +124,12 @@ main {
   justify-content: space-between;
 }
 
+.topbar-top-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .topbar-row-bottom {
   justify-content: space-between;
   flex-wrap: wrap;
@@ -769,6 +775,17 @@ main {
 }
 
 .muted { color: var(--muted); font-size: 13px; }
+
+/* Install instructions list */
+.install-steps {
+  margin: 12px 0 18px;
+  padding: 0 0 0 22px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--ink);
+}
+.install-steps li { margin-bottom: 8px; }
+.install-steps strong { color: var(--accent); font-weight: 700; }
 
 /* ---------- History ---------- */
 .history-list {


### PR DESCRIPTION
## Summary

Turns Budget Quest into an installable Progressive Web App. After this lands, mobile users get a real "Add to Home Screen" experience — full-screen, fast launch, app icon, works offline.

### What's added

- **`icon.svg`** — gradient `$` on a rounded square, maskable, scales to any size
- **`manifest.webmanifest`** — name, theme color, standalone display mode, scope
- **`service-worker.js`** — stale-while-revalidate for same-origin assets so the app loads instantly from cache and updates in the background. Cross-origin Firebase/gstatic requests pass through untouched.
- **HTML meta tags** — `theme-color`, `apple-touch-icon`, `apple-mobile-web-app-capable`, `apple-mobile-web-app-title`
- **📱 Install button** in the topbar (top right) — only visible when actionable
- **iOS install instructions modal** — shows the Share → Add to Home Screen flow

### How install works for each platform

- **Chrome / Edge / Android Chrome:** `beforeinstallprompt` fires; we capture it, show the **📱 Install** pill, and call `.prompt()` on tap → native install dialog → confetti on success.
- **iOS Safari:** no programmatic prompt, so we show the button and open a clean modal explaining "Tap Share → Add to Home Screen → Add". Once installed, iOS launches the app full-screen with the icon on the home screen.
- **Already installed (`display-mode: standalone`):** install button stays hidden.

### Offline support

Service worker caches the static assets on first load. Subsequent visits are instant from cache, with background network refresh. Firebase real-time sync still works when online; offline you get the last cached state.

## Test plan

- [ ] **Chrome desktop:** Install button appears in topbar; click → native install dialog → app installs as a desktop window
- [ ] **Android Chrome:** same as above; app installs to home screen
- [ ] **iOS Safari:** Install button visible; tap opens the instructions modal; following the steps adds the app to the home screen
- [ ] **Already-installed launch:** Install button hidden, app runs full-screen
- [ ] **Offline:** Reload with airplane mode on — app still loads from cache
- [ ] **Online refresh:** New deploy shows up after one reload (background update)
- [ ] **Firefox / unsupported:** Install button just doesn't appear; everything else works

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_