### PR TITLE
Edit/delete expenses, recurring entries, notes, donut chart

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,7 +65,9 @@ import { firebaseConfig } from './firebase-config.js';
    */
   let data = migrate(load());
   let editingCategoryId = null;       // when set, category modal is editing
-  let activeExpenseTarget = null;     // {categoryId}
+  let activeExpenseTarget = null;     // {categoryId, expenseId?} — expenseId set means edit mode
+  let editingIncomeId = null;         // income modal: id when editing, null when adding
+  let listingCategoryId = null;       // category whose all-expenses modal is open
   let viewingMonth = null;            // when viewing historical (read-only)
   let confirmAction = null;
   let syncState = 'local';            // local | connecting | synced | syncing | offline | error
@@ -175,8 +177,84 @@ import { firebaseConfig } from './firebase-config.js';
   function render() {
     renderHeader();
     renderDashboard();
+    renderChart();
     renderIncome();
     renderCategories();
+  }
+
+  function renderChart() {
+    const m = getMonth();
+    const section = document.getElementById('breakdown-section');
+    const container = document.getElementById('chart-container');
+    const slices = (m.categories || [])
+      .map(c => ({ id: c.id, name: c.name, color: c.color || '#7c5cff', icon: c.icon, value: categorySpent(c) }))
+      .filter(s => s.value > 0);
+
+    const total = slices.reduce((s, x) => s + x.value, 0);
+    if (total <= 0) {
+      section.hidden = true;
+      container.innerHTML = '';
+      return;
+    }
+    section.hidden = false;
+    slices.sort((a, b) => b.value - a.value);
+
+    const r = 80;
+    const stroke = 26;
+    const cx = 100, cy = 100;
+    const circumference = 2 * Math.PI * r;
+    let dashOffset = 0;
+    const segments = slices.map(s => {
+      const fraction = s.value / total;
+      const length = fraction * circumference;
+      const seg = {
+        ...s,
+        fraction,
+        length,
+        offset: dashOffset
+      };
+      dashOffset += length;
+      return seg;
+    });
+
+    const segMarkup = segments.map(seg => `
+      <circle class="donut-segment"
+              cx="${cx}" cy="${cy}" r="${r}"
+              stroke="${seg.color}"
+              stroke-dasharray="${seg.length.toFixed(2)} ${(circumference - seg.length).toFixed(2)}"
+              stroke-dashoffset="${(-seg.offset).toFixed(2)}"
+              transform="rotate(-90 ${cx} ${cy})"></circle>
+    `).join('');
+
+    const legendMarkup = segments.map(seg => `
+      <div class="donut-legend-item" data-cat="${seg.id}">
+        <span class="swatch" style="background: ${seg.color}"></span>
+        <span class="legend-name">${seg.icon ? seg.icon + ' ' : ''}${escapeHtml(seg.name)}</span>
+        <span><span class="legend-amount">${fmt(seg.value)}</span><span class="legend-pct">${Math.round(seg.fraction * 100)}%</span></span>
+      </div>
+    `).join('');
+
+    container.innerHTML = `
+      <div class="donut-wrap">
+        <svg class="donut-svg" viewBox="0 0 200 200" aria-hidden="true">
+          <circle class="donut-track" cx="${cx}" cy="${cy}" r="${r}"></circle>
+          ${segMarkup}
+        </svg>
+        <div class="donut-center">
+          <div>
+            <div class="donut-total">${fmt(total)}</div>
+            <div class="donut-label">Spent this month</div>
+          </div>
+        </div>
+      </div>
+      <div class="donut-legend">${legendMarkup}</div>
+    `;
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => (
+      { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+    ));
   }
 
   function renderHeader() {
@@ -230,23 +308,26 @@ import { firebaseConfig } from './firebase-config.js';
       list.appendChild(empty);
       return;
     }
+    const ro = isReadOnly();
     m.income.forEach((inc, i) => {
       const el = document.createElement('div');
       el.className = 'income-item';
       el.style.animationDelay = `${i * 0.04}s`;
+      const recurring = inc.recurring ? '<span class="recurring-icon" title="Recurring">🔁</span>' : '';
       el.innerHTML = `
-        <div>
-          <div class="name"></div>
+        <div class="name-block">
+          <div class="name">${recurring}<span class="inc-name-text"></span></div>
         </div>
         <div style="display:flex;align-items:center;">
           <span class="amount"></span>
-          ${isReadOnly() ? '' : '<button class="delete" title="Remove">×</button>'}
         </div>
       `;
-      el.querySelector('.name').textContent = inc.name;
+      el.querySelector('.inc-name-text').textContent = inc.name;
       el.querySelector('.amount').textContent = fmt(inc.amount);
-      const del = el.querySelector('.delete');
-      if (del) del.addEventListener('click', () => removeIncome(inc.id));
+      if (!ro) {
+        el.style.cursor = 'pointer';
+        el.addEventListener('click', () => openIncomeModal(inc.id));
+      }
       list.appendChild(el);
     });
   }
@@ -312,22 +393,32 @@ import { firebaseConfig } from './firebase-config.js';
     card.querySelector('.cat-name').textContent = cat.name;
     card.querySelector('.cat-amounts').textContent = `${fmt(spent)} of ${fmt(limit)}`;
 
-    // Recent expenses (chips)
-    const recentExpenses = (cat.expenses || []).slice(-3).reverse();
+    // Recent expenses (clickable chips). Show last 3 + "View all" if more.
+    const allExpenses = cat.expenses || [];
+    const recentExpenses = allExpenses.slice(-3).reverse();
     if (recentExpenses.length) {
       const recent = document.createElement('div');
       recent.className = 'recent';
       recentExpenses.forEach(e => {
-        const chip = document.createElement('span');
-        chip.className = 'chip';
-        const nameSpan = document.createElement('span');
-        nameSpan.textContent = e.name;
-        const amt = document.createElement('strong');
-        amt.textContent = fmt(e.amount);
-        chip.appendChild(nameSpan);
-        chip.appendChild(amt);
+        const chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = 'chip chip-clickable';
+        chip.title = e.note ? `${e.name} — ${e.note}` : e.name;
+        const recurring = e.recurring ? '<span class="recurring-icon">🔁</span> ' : '';
+        chip.innerHTML = `${recurring}<span></span><strong></strong>`;
+        chip.querySelectorAll('span')[recurring ? 1 : 0].textContent = e.name;
+        chip.querySelector('strong').textContent = fmt(e.amount);
+        if (!ro) chip.addEventListener('click', () => openExpenseModal(cat.id, e.id));
         recent.appendChild(chip);
       });
+      if (allExpenses.length > 3) {
+        const more = document.createElement('button');
+        more.type = 'button';
+        more.className = 'chip chip-more';
+        more.textContent = `View all (${allExpenses.length})`;
+        more.addEventListener('click', () => openExpenseListModal(cat.id));
+        recent.appendChild(more);
+      }
       card.appendChild(recent);
     }
 
@@ -345,14 +436,30 @@ import { firebaseConfig } from './firebase-config.js';
   }
 
   // ---------- Mutations ----------
-  function addIncome(name, amount) {
+  function addIncome({ name, amount, note, recurring }) {
     if (isReadOnly()) return;
     const m = getMonth();
-    m.income.push({ id: uid(), name, amount: +amount });
+    m.income.push({
+      id: uid(),
+      name,
+      amount: +amount,
+      note: note || '',
+      recurring: !!recurring
+    });
     save();
     render();
     fireConfetti(['#10b981', '#34d399', '#06b6d4']);
     toast(`+${fmt(amount)} income added 💸`, 'success');
+  }
+
+  function updateIncome(id, patch) {
+    if (isReadOnly()) return;
+    const m = getMonth();
+    const inc = (m.income || []).find(i => i.id === id);
+    if (!inc) return;
+    Object.assign(inc, patch);
+    save();
+    render();
   }
 
   function removeIncome(id) {
@@ -393,13 +500,19 @@ import { firebaseConfig } from './firebase-config.js';
     if (cat) toast(`Removed "${cat.name}"`, 'info');
   }
 
-  function addExpense(categoryId, name, amount) {
+  function addExpense(categoryId, { name, amount, note, recurring }) {
     if (isReadOnly()) return;
     const m = getMonth();
     const cat = m.categories.find(c => c.id === categoryId);
     if (!cat) return;
     cat.expenses = cat.expenses || [];
-    cat.expenses.push({ id: uid(), name, amount: +amount });
+    cat.expenses.push({
+      id: uid(),
+      name,
+      amount: +amount,
+      note: note || '',
+      recurring: !!recurring
+    });
     save();
     render();
 
@@ -412,6 +525,29 @@ import { firebaseConfig } from './firebase-config.js';
     } else if (limit > 0 && spent / limit >= 0.8) {
       toast(`Watch out — "${cat.name}" at ${Math.round(spent / limit * 100)}%`, 'info');
     }
+  }
+
+  function updateExpense(categoryId, expenseId, patch) {
+    if (isReadOnly()) return;
+    const m = getMonth();
+    const cat = m.categories.find(c => c.id === categoryId);
+    if (!cat) return;
+    const exp = (cat.expenses || []).find(e => e.id === expenseId);
+    if (!exp) return;
+    Object.assign(exp, patch);
+    save();
+    render();
+  }
+
+  function deleteExpense(categoryId, expenseId) {
+    if (isReadOnly()) return;
+    const m = getMonth();
+    const cat = m.categories.find(c => c.id === categoryId);
+    if (!cat) return;
+    cat.expenses = (cat.expenses || []).filter(e => e.id !== expenseId);
+    save();
+    render();
+    toast('Expense removed', 'info');
   }
 
   function startNewMonth() {
@@ -430,7 +566,9 @@ import { firebaseConfig } from './firebase-config.js';
       key = monthKey(next);
     }
 
-    // Carry over category structure with reset spending
+    // Carry over category structure with reset spending — but recurring
+    // expenses get auto-copied into the new month so things like rent and
+    // subscriptions don't have to be re-entered every month.
     const prev = data.months[data.currentMonth];
     const carriedCategories = (prev?.categories || []).map(c => ({
       id: uid(),
@@ -438,16 +576,25 @@ import { firebaseConfig } from './firebase-config.js';
       limit: c.limit,
       color: c.color,
       icon: c.icon,
-      expenses: []
+      expenses: (c.expenses || [])
+        .filter(e => e.recurring)
+        .map(e => ({ id: uid(), name: e.name, amount: e.amount, note: e.note || '', recurring: true }))
     }));
 
-    data.months[key] = { income: [], categories: carriedCategories };
+    // Carry over recurring income too.
+    const carriedIncome = (prev?.income || [])
+      .filter(i => i.recurring)
+      .map(i => ({ id: uid(), name: i.name, amount: i.amount, note: i.note || '', recurring: true }));
+
+    data.months[key] = { income: carriedIncome, categories: carriedCategories };
     data.currentMonth = key;
     viewingMonth = null;
     save();
     render();
     fireConfetti();
-    toast(`New month started: ${monthLabel(key)} 🚀`, 'success');
+    const recurringCount = carriedIncome.length + carriedCategories.reduce((s, c) => s + c.expenses.length, 0);
+    const note = recurringCount > 0 ? ` (${recurringCount} recurring auto-added 🔁)` : '';
+    toast(`New month started: ${monthLabel(key)}${note} 🚀`, 'success');
   }
 
   /**
@@ -548,25 +695,119 @@ import { firebaseConfig } from './firebase-config.js';
     });
   }
 
-  function openExpenseModal(categoryId) {
+  function openExpenseModal(categoryId, expenseId) {
     if (isReadOnly()) return;
-    activeExpenseTarget = { categoryId };
+    const cat = getMonth().categories.find(c => c.id === categoryId);
+    if (!cat) return;
+    activeExpenseTarget = { categoryId, expenseId: expenseId || null };
+
     const modal = document.getElementById('expense-modal');
     const title = document.getElementById('expense-modal-title');
-    const cat = getMonth().categories.find(c => c.id === categoryId);
-    title.textContent = `Add to ${cat.name}`;
-    document.getElementById('exp-name').value = '';
-    document.getElementById('exp-amount').value = '';
+    const nameEl = document.getElementById('exp-name');
+    const amountEl = document.getElementById('exp-amount');
+    const noteEl = document.getElementById('exp-note');
+    const recurringEl = document.getElementById('exp-recurring');
+    const saveBtn = document.getElementById('exp-save-btn');
+    const deleteBtn = document.getElementById('exp-delete-btn');
+
+    if (expenseId) {
+      const exp = (cat.expenses || []).find(e => e.id === expenseId);
+      if (!exp) return;
+      title.textContent = `Edit · ${cat.name}`;
+      nameEl.value = exp.name || '';
+      amountEl.value = exp.amount;
+      noteEl.value = exp.note || '';
+      recurringEl.checked = !!exp.recurring;
+      saveBtn.textContent = 'Save';
+      deleteBtn.hidden = false;
+    } else {
+      title.textContent = `Add to ${cat.name}`;
+      nameEl.value = '';
+      amountEl.value = '';
+      noteEl.value = '';
+      recurringEl.checked = false;
+      saveBtn.textContent = 'Add';
+      deleteBtn.hidden = true;
+    }
     modal.hidden = false;
-    setTimeout(() => document.getElementById('exp-name').focus(), 50);
+    setTimeout(() => nameEl.focus(), 50);
   }
 
-  function openIncomeModal() {
+  function openIncomeModal(incomeId) {
     if (isReadOnly()) return;
-    document.getElementById('inc-name').value = '';
-    document.getElementById('inc-amount').value = '';
+    editingIncomeId = incomeId || null;
+
+    const title = document.getElementById('income-modal-title');
+    const nameEl = document.getElementById('inc-name');
+    const amountEl = document.getElementById('inc-amount');
+    const noteEl = document.getElementById('inc-note');
+    const recurringEl = document.getElementById('inc-recurring');
+    const saveBtn = document.getElementById('inc-save-btn');
+    const deleteBtn = document.getElementById('inc-delete-btn');
+
+    if (incomeId) {
+      const inc = (getMonth().income || []).find(i => i.id === incomeId);
+      if (!inc) return;
+      title.textContent = 'Edit Income';
+      nameEl.value = inc.name || '';
+      amountEl.value = inc.amount;
+      noteEl.value = inc.note || '';
+      recurringEl.checked = !!inc.recurring;
+      saveBtn.textContent = 'Save';
+      deleteBtn.hidden = false;
+    } else {
+      title.textContent = 'Add Income';
+      nameEl.value = '';
+      amountEl.value = '';
+      noteEl.value = '';
+      recurringEl.checked = false;
+      saveBtn.textContent = 'Add';
+      deleteBtn.hidden = true;
+    }
     document.getElementById('income-modal').hidden = false;
-    setTimeout(() => document.getElementById('inc-name').focus(), 50);
+    setTimeout(() => nameEl.focus(), 50);
+  }
+
+  function openExpenseListModal(categoryId) {
+    listingCategoryId = categoryId;
+    const cat = getMonth().categories.find(c => c.id === categoryId);
+    if (!cat) return;
+    const title = document.getElementById('expense-list-title');
+    const body = document.getElementById('expense-list-body');
+    const ro = isReadOnly();
+    title.textContent = `${cat.icon || '🛒'}  ${cat.name} expenses`;
+    const expenses = [...(cat.expenses || [])].reverse();
+    if (expenses.length === 0) {
+      body.innerHTML = '<div class="empty-row">No expenses yet for this category.</div>';
+    } else {
+      body.innerHTML = '';
+      expenses.forEach(e => {
+        const row = document.createElement('div');
+        row.className = 'expense-row';
+        const recurring = e.recurring ? '<span class="recurring-icon" title="Recurring">🔁</span>' : '';
+        const note = e.note ? `<div class="expense-note"></div>` : '';
+        row.innerHTML = `
+          <div class="expense-main">
+            <div class="expense-name">${recurring}<span class="exp-name-text"></span></div>
+            ${note}
+          </div>
+          <div class="expense-amount"></div>
+        `;
+        row.querySelector('.exp-name-text').textContent = e.name;
+        row.querySelector('.expense-amount').textContent = fmt(e.amount);
+        if (e.note) row.querySelector('.expense-note').textContent = e.note;
+        if (!ro) {
+          row.addEventListener('click', () => {
+            document.getElementById('expense-list-modal').hidden = true;
+            openExpenseModal(categoryId, e.id);
+          });
+        } else {
+          row.style.cursor = 'default';
+        }
+        body.appendChild(row);
+      });
+    }
+    document.getElementById('expense-list-modal').hidden = false;
   }
 
   function openHistoryModal() {
@@ -865,25 +1106,57 @@ import { firebaseConfig } from './firebase-config.js';
       closeAllModals();
     });
 
-    // Expense form
+    // Expense form (add OR edit)
     document.getElementById('expense-form').addEventListener('submit', (e) => {
       e.preventDefault();
+      if (!activeExpenseTarget) return;
       const name = document.getElementById('exp-name').value.trim();
       const amount = +document.getElementById('exp-amount').value;
-      if (!name || amount < 0 || !activeExpenseTarget) return;
-      addExpense(activeExpenseTarget.categoryId, name, amount);
+      const note = document.getElementById('exp-note').value.trim();
+      const recurring = document.getElementById('exp-recurring').checked;
+      if (!name || amount < 0) return;
+      const { categoryId, expenseId } = activeExpenseTarget;
+      if (expenseId) {
+        updateExpense(categoryId, expenseId, { name, amount: +amount, note, recurring });
+      } else {
+        addExpense(categoryId, { name, amount, note, recurring });
+      }
       activeExpenseTarget = null;
       closeAllModals();
     });
 
-    // Income form
+    document.getElementById('exp-delete-btn').addEventListener('click', () => {
+      if (!activeExpenseTarget || !activeExpenseTarget.expenseId) return;
+      const { categoryId, expenseId } = activeExpenseTarget;
+      activeExpenseTarget = null;
+      closeAllModals();
+      deleteExpense(categoryId, expenseId);
+    });
+
+    // Income form (add OR edit)
     document.getElementById('income-form').addEventListener('submit', (e) => {
       e.preventDefault();
       const name = document.getElementById('inc-name').value.trim();
       const amount = +document.getElementById('inc-amount').value;
+      const note = document.getElementById('inc-note').value.trim();
+      const recurring = document.getElementById('inc-recurring').checked;
       if (!name || amount < 0) return;
-      addIncome(name, amount);
+      if (editingIncomeId) {
+        updateIncome(editingIncomeId, { name, amount: +amount, note, recurring });
+      } else {
+        addIncome({ name, amount, note, recurring });
+      }
+      editingIncomeId = null;
       closeAllModals();
+    });
+
+    document.getElementById('inc-delete-btn').addEventListener('click', () => {
+      if (!editingIncomeId) return;
+      const id = editingIncomeId;
+      editingIncomeId = null;
+      closeAllModals();
+      removeIncome(id);
+      toast('Income removed', 'info');
     });
 
     // Confirm modal

--- a/index.html
+++ b/index.html
@@ -114,6 +114,14 @@
       </div>
     </section>
 
+    <!-- Spending Breakdown -->
+    <section class="section breakdown-section" id="breakdown-section" hidden>
+      <div class="section-header">
+        <h2>📊 Where the money went</h2>
+      </div>
+      <div id="chart-container" class="chart-container"></div>
+    </section>
+
     <!-- Income Section -->
     <section class="section income-section">
       <div class="section-header">
@@ -172,7 +180,7 @@
     </div>
   </div>
 
-  <!-- Modal: Add Expense -->
+  <!-- Modal: Add / Edit Expense -->
   <div class="modal" id="expense-modal" hidden>
     <div class="modal-backdrop" data-close></div>
     <div class="modal-card">
@@ -187,20 +195,29 @@
           Amount ($)
           <input type="number" id="exp-amount" required min="0" step="0.01" placeholder="0.00" />
         </label>
+        <label>
+          Note <span class="label-hint">(optional)</span>
+          <input type="text" id="exp-note" maxlength="200" placeholder="e.g. Costco run, weekly produce" />
+        </label>
+        <label class="checkbox-row">
+          <input type="checkbox" id="exp-recurring" />
+          <span class="checkbox-text"><strong>🔁 Recurring</strong> — auto-add to every new month</span>
+        </label>
         <div class="modal-actions">
+          <button type="button" class="danger-btn" id="exp-delete-btn" hidden>Delete</button>
           <button type="button" class="ghost-btn" data-close>Cancel</button>
-          <button type="submit" class="primary-btn">Add</button>
+          <button type="submit" class="primary-btn" id="exp-save-btn">Add</button>
         </div>
       </form>
     </div>
   </div>
 
-  <!-- Modal: Add Income -->
+  <!-- Modal: Add / Edit Income -->
   <div class="modal" id="income-modal" hidden>
     <div class="modal-backdrop" data-close></div>
     <div class="modal-card">
       <button class="modal-close" data-close>×</button>
-      <h3>Add Income</h3>
+      <h3 id="income-modal-title">Add Income</h3>
       <form id="income-form">
         <label>
           Source
@@ -210,11 +227,30 @@
           Amount ($)
           <input type="number" id="inc-amount" required min="0" step="0.01" placeholder="0.00" />
         </label>
+        <label>
+          Note <span class="label-hint">(optional)</span>
+          <input type="text" id="inc-note" maxlength="200" placeholder="e.g. side gig, end-of-month bonus" />
+        </label>
+        <label class="checkbox-row">
+          <input type="checkbox" id="inc-recurring" />
+          <span class="checkbox-text"><strong>🔁 Recurring</strong> — auto-add to every new month</span>
+        </label>
         <div class="modal-actions">
+          <button type="button" class="danger-btn" id="inc-delete-btn" hidden>Delete</button>
           <button type="button" class="ghost-btn" data-close>Cancel</button>
-          <button type="submit" class="primary-btn">Add</button>
+          <button type="submit" class="primary-btn" id="inc-save-btn">Add</button>
         </div>
       </form>
+    </div>
+  </div>
+
+  <!-- Modal: Full expense list for one category -->
+  <div class="modal" id="expense-list-modal" hidden>
+    <div class="modal-backdrop" data-close></div>
+    <div class="modal-card modal-wide">
+      <button class="modal-close" data-close>×</button>
+      <h3 id="expense-list-title">Expenses</h3>
+      <div id="expense-list-body" class="expense-list-body"></div>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Budget Quest — Track. Slay. Save.</title>
+  <title>Budget Quest</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%92%B0%3C/text%3E%3C/svg%3E" />
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="theme-color" content="#6366f1" />

--- a/styles.css
+++ b/styles.css
@@ -655,13 +655,40 @@ main {
 }
 .recent .chip {
   font-size: 11px;
-  padding: 3px 10px;
+  padding: 4px 10px;
   border-radius: 999px;
   background: var(--bg-1);
   border: 1px solid var(--line);
   color: var(--ink-dim);
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
 }
-.recent .chip strong { color: var(--ink); margin-left: 4px; font-variant-numeric: tabular-nums; }
+.recent .chip strong { color: var(--ink); margin-left: 4px; font-variant-numeric: tabular-nums; font-weight: 700; }
+.recent .chip-clickable {
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.recent .chip-clickable:hover {
+  background: var(--surface);
+  border-color: var(--line-strong);
+  color: var(--ink);
+  transform: translateY(-1px);
+}
+.recent .chip-clickable:active { transform: scale(0.96); }
+.recent .chip-more {
+  cursor: pointer;
+  background: transparent;
+  border-style: dashed;
+  color: var(--accent);
+  font-weight: 600;
+  transition: background 0.15s ease, transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.recent .chip-more:hover {
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+  transform: translateY(-1px);
+}
 
 /* ---------- Empty state ---------- */
 .empty-state {
@@ -807,6 +834,173 @@ main {
 }
 
 .muted { color: var(--muted); font-size: 13px; }
+.label-hint { font-weight: 400; text-transform: none; letter-spacing: 0; color: var(--muted); margin-left: 4px; }
+
+/* Checkbox row inside modals */
+.checkbox-row {
+  display: flex !important;
+  align-items: center;
+  gap: 10px;
+  text-transform: none !important;
+  letter-spacing: 0 !important;
+  font-weight: 500 !important;
+  font-size: 13px !important;
+  color: var(--ink) !important;
+  cursor: pointer;
+  padding: 10px 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  margin-bottom: 14px;
+}
+.checkbox-row input[type="checkbox"] {
+  width: 18px; height: 18px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.checkbox-row .checkbox-text strong { color: var(--ink); font-weight: 600; }
+
+/* All-expenses modal list */
+.expense-list-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 60vh;
+  overflow-y: auto;
+  margin-top: 4px;
+}
+.expense-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.expense-row:hover {
+  background: var(--surface);
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+}
+.expense-row:active { transform: scale(0.98); }
+.expense-row .expense-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
+.expense-row .expense-name {
+  font-size: 14px; font-weight: 600; color: var(--ink);
+  display: flex; align-items: center; gap: 6px;
+}
+.expense-row .expense-note { font-size: 11.5px; color: var(--muted); }
+.expense-row .expense-amount {
+  font-size: 14px; font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+.recurring-icon {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+/* Spending breakdown */
+.chart-container {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  gap: 28px;
+  align-items: center;
+  padding: 22px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+}
+.donut-wrap {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+.donut-svg {
+  width: 220px; height: 220px;
+  display: block;
+}
+.donut-svg .donut-track {
+  fill: none;
+  stroke: var(--bg-1);
+  stroke-width: 26;
+}
+.donut-svg .donut-segment {
+  fill: none;
+  stroke-width: 26;
+  stroke-linecap: butt;
+  transition: stroke-width 0.2s ease;
+}
+.donut-center {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  text-align: center;
+}
+.donut-center .donut-total {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--ink);
+  letter-spacing: -0.5px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.donut-center .donut-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+.donut-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.donut-legend-item {
+  display: grid;
+  grid-template-columns: 14px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 4px;
+  font-size: 13px;
+}
+.donut-legend-item .swatch {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+}
+.donut-legend-item .legend-name {
+  color: var(--ink);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.donut-legend-item .legend-amount {
+  color: var(--ink-dim);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.donut-legend-item .legend-pct {
+  color: var(--muted);
+  font-size: 11.5px;
+  margin-left: 6px;
+}
+@media (max-width: 700px) {
+  .chart-container { grid-template-columns: 1fr; gap: 16px; padding: 18px; }
+  .donut-svg { width: 180px; height: 180px; }
+  .donut-center .donut-total { font-size: 18px; }
+}
 
 /* Install instructions list */
 .install-steps {


### PR DESCRIPTION
## Summary

Four features bundled — the four highest-priority items from the previous PR's "next improvements" list (skipping CSV export per request).

### 1. Edit / delete individual expenses (and income)

- **Expense chips** on each category card are now clickable buttons. Tap one → expense modal opens in **edit mode** with name, amount, note, recurring, and a **Delete** button.
- When a category has more than 3 expenses, a **"View all (N)"** chip opens a dedicated modal listing every expense for that category. Each row is tappable to edit.
- **Income items** are clickable too — opens the income modal in edit mode (replaces the old × hover-delete; delete is now in the edit modal alongside the other fields).
- Add and edit share the same modals; mode is determined by whether the **Delete** button is shown and what the title / save-button label say.

### 2. Recurring transactions

- New **🔁 Recurring** checkbox on both expense and income modals.
- When you tap **↻ New Month**, any entries flagged recurring get auto-copied into the new month with fresh IDs but the same name, amount, and note.
- Recurring entries display a small 🔁 marker next to their name (in chips, in the all-expenses list, and in income items).
- Toast on new-month creation tells you how many recurring items carried over.

This means rent, paycheck, Netflix, etc. only have to be entered once.

### 3. Notes per entry

- Optional **Note** field on both modals, max 200 chars (e.g. "Costco run, weekly produce").
- Shown as muted text under the name in the all-expenses list.
- Set as the chip's `title` tooltip on hover too.

### 4. Spending breakdown donut chart

- New **📊 Where the money went** section between the dashboard and income.
- SVG donut, one segment per category, colored to match each. Center shows total spent for the month.
- Legend on the right (or below on mobile) shows icon + name + amount + percentage per category.
- Hidden when there's no spending yet (no clutter on a fresh month).

### What was skipped

- **CSV export** — punted per request; can add later.

## Test plan

- [ ] Click a chip on a category → expense edit modal opens with values populated; saving updates the data; deleting removes it
- [ ] Add 4+ expenses to a category → "View all" chip appears; tapping opens the full list; tapping a row opens edit
- [ ] Tap an income item → edit modal with delete; saving + deleting both work
- [ ] Tick **🔁 Recurring** on a few entries (one income, one expense) → tap **↻ New Month** → those auto-appear in the fresh month with fresh IDs
- [ ] Add a note → shows up in the all-expenses modal under the name
- [ ] Add expenses across multiple categories → donut renders with proportional segments and a correct legend
- [ ] Empty month (no spending) → donut section is hidden
- [ ] Dark mode + light mode both render the donut + legend correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_