### PR TITLE
Fix Add Income button being unresponsive

### DIFF
--- a/app.js
+++ b/app.js
@@ -1078,7 +1078,7 @@ import { firebaseConfig } from './firebase-config.js';
     document.getElementById('history-btn').addEventListener('click', openHistoryModal);
 
     // Add buttons
-    document.getElementById('add-income-btn').addEventListener('click', openIncomeModal);
+    document.getElementById('add-income-btn').addEventListener('click', () => openIncomeModal());
     document.getElementById('add-category-btn').addEventListener('click', () => openCategoryModal());
 
     // Modal close-on-backdrop / × / Esc


### PR DESCRIPTION
## Summary

Hotfix for the **+ Add Income** button being unresponsive after PR #37.

**The bug:** `addEventListener('click', openIncomeModal)` passes the click MouseEvent as the first argument to the function. Since `openIncomeModal(incomeId)` treats any truthy first arg as edit mode, it tried to look up an income with id === `[object MouseEvent]`, found none, and silently returned. Modal never opened.

**The fix:** wrap in an arrow so the function is called with no args (add mode), the same way `add-category-btn` is already wired.

## Test plan
- [ ] Click **+ Add Income** → modal opens
- [ ] Submit a new income → it appears in the list
- [ ] Click an existing income → still opens in edit mode (regression check)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_