### PR TITLE
Migrate remote sync payloads (fixes Sync error after PR #40)

### DIFF
--- a/app.js
+++ b/app.js
@@ -986,7 +986,8 @@ import { firebaseConfig } from './firebase-config.js';
     } catch (e) {
       console.warn('Sync init failed', e);
       setSyncStatus('error');
-      toast('Could not start sync. Working offline.', 'error');
+      const detail = e?.code || e?.message || 'unknown';
+      toast(`Sync init failed: ${detail}`, 'error');
     }
   }
 
@@ -1002,7 +1003,7 @@ import { firebaseConfig } from './firebase-config.js';
       localStorage.setItem(HOUSEHOLD_KEY, code);
       if (remote) {
         suspendPush = true;
-        data = remote;
+        data = migrate(remote);
         localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
         suspendPush = false;
         render();
@@ -1017,7 +1018,8 @@ import { firebaseConfig } from './firebase-config.js';
     } catch (e) {
       console.warn('joinHousehold failed', e);
       setSyncStatus('error');
-      toast('Could not join household. Try again.', 'error');
+      const detail = e?.code || e?.message || 'unknown';
+      toast(`Could not join household: ${detail}`, 'error');
       return false;
     }
   }
@@ -1025,7 +1027,9 @@ import { firebaseConfig } from './firebase-config.js';
   function applyRemote(remoteData) {
     if (!remoteData) return;
     suspendPush = true;
-    data = remoteData;
+    // Remote payloads from older clients may still use the legacy
+    // months/cycles shape — run migration before using.
+    data = migrate(remoteData);
     if (viewingPeriod && !data.periods[viewingPeriod]) viewingPeriod = null;
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     suspendPush = false;

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,7 @@
  * and need fresh tokens).
  */
 
-const CACHE = 'budget-quest-v2';
+const CACHE = 'budget-quest-v3';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary

Hotfix for the "Sync error" you're seeing after PR #40 (the months → pay periods refactor).

### The bug

When PR #40 deployed, the household's Firestore document still has the **old** shape (`{months, currentMonth}`). When the new client fetches that document and does `data = remote;` directly, it bypasses the `migrate()` that normally runs on local load. So `data.periods` stays undefined, every render path that touches it crashes, and the catch handler surfaces a generic "Sync error."

This affects:
- Initial join: pulling the existing household doc fails
- Real-time updates: an incoming `onSnapshot` payload from an old-shape doc breaks

### The fix

Run `migrate()` on remote payloads in both places they're applied (`joinHousehold` and `applyRemote`). The migration already handles `months → periods` and even an interim `cycles → periods` shape (left over from the in-progress branch).

### Also

- **Better error reporting** — the toast now shows the actual Firebase error code/message (e.g. `permission-denied`, `unavailable`) instead of "Could not join household. Try again." Saves a trip to DevTools next time something goes sideways.
- **Bumped service-worker cache to v3** so devices that cached the old broken bundle fetch the fix on the next reload.

## Test plan

- [ ] Open the live site with sync enabled — household setup loads without error
- [ ] If a sync error persists, the toast now shows the actual Firebase error code
- [ ] On a fresh device, **Join existing** with your household code → joins, pulls migrated data, no error
- [ ] Add an expense → other device picks it up via the real-time listener
- [ ] Existing months auto-convert to periods starting on the 1st of that month (no data loss)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_