### PR TITLE
Show pay period as just the start date (no synthetic end)

### DIFF
--- a/app.js
+++ b/app.js
@@ -164,27 +164,17 @@ import { firebaseConfig } from './firebase-config.js';
   }
 
   /**
-   * Render a period's start/end date range as a label.
-   * The end date is the day before the next chronological period starts;
-   * the chronologically-latest period shows "Apr 24 – ongoing".
+   * Render a period as its start date (the paycheck date).
+   * Earlier versions showed a "May 27 – Jun 25" range, but migrated
+   * periods inherited calendar-month boundaries that didn't correspond
+   * to actual paychecks. The start date is the only honest signal —
+   * it's the day the period began, i.e. when you got paid.
    */
   function periodLabel(key) {
-    const keys = Object.keys(data.periods).sort();
-    const idx = keys.indexOf(key);
     const start = parsePeriodKey(key);
-    const startStr = start.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-
-    if (idx === -1 || idx === keys.length - 1) {
-      return `${startStr} – ongoing`;
-    }
-    const nextStart = parsePeriodKey(keys[idx + 1]);
-    const end = new Date(nextStart);
-    end.setDate(end.getDate() - 1);
-    const endStr = end.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-    if (start.getFullYear() !== end.getFullYear()) {
-      return `${startStr} ${start.getFullYear()} – ${endStr} ${end.getFullYear()}`;
-    }
-    return `${startStr} – ${endStr}`;
+    const opts = { month: 'short', day: 'numeric' };
+    if (start.getFullYear() !== new Date().getFullYear()) opts.year = 'numeric';
+    return start.toLocaleDateString(undefined, opts);
   }
 
   function fmt(n) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,7 @@
  * and need fresh tokens).
  */
 
-const CACHE = 'budget-quest-v3';
+const CACHE = 'budget-quest-v4';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary

The period label was showing a date range (e.g. `May 1 – May 31`) computed by taking the day before the next period's start. That worked fine for periods *you* create going forward, but for migrated month data it surfaced **synthetic calendar boundaries** that didn't correspond to actual paychecks — implying confidence about an end date that wasn't real.

### Fix

Drop the range. Show just the **start date** (the paycheck date). Year is appended only when it differs from the current year (e.g. `May 27` for this year, `Dec 28, 2025` for cross-year).

Used everywhere the label appears: header, history modal, toasts, confirmation copy.

### Why start-date-only

- It's the only honestly-known boundary
- It IS the paycheck date, so it's the meaningful identifier
- The end of any past period is implicit (= start of the next one in history)

Service-worker cache bumped to `v4` so devices fetch the fix on next reload.

### If you'd rather have zero dates

Just say so — I can switch to ordinals like `Pay Period 1`, `Pay Period 2`, but you'd lose the at-a-glance "which paycheck was this."

## Test plan

- [ ] Header shows just the start date (e.g. `May 27`)
- [ ] History modal lists past periods by start date only
- [ ] Cross-year periods include the year (e.g. `Dec 28, 2025`)
- [ ] Toasts and confirmations read naturally

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_