### PR TITLE
Pay period range: fixed 4 weeks + overdue label flip + nudge banner

### DIFF
--- a/app.js
+++ b/app.js
@@ -164,17 +164,22 @@ import { firebaseConfig } from './firebase-config.js';
   }
 
   /**
-   * Render a period as its start date (the paycheck date).
-   * Earlier versions showed a "May 27 – Jun 25" range, but migrated
-   * periods inherited calendar-month boundaries that didn't correspond
-   * to actual paychecks. The start date is the only honest signal —
-   * it's the day the period began, i.e. when you got paid.
+   * Render a period as a roughly-4-week range starting from its
+   * paycheck date. The actual gap between paychecks isn't fixed
+   * (varies with weekends/holidays), but 28 days is a reasonable
+   * approximation and keeps every period's label honest regardless
+   * of what the next period's start happens to be.
    */
   function periodLabel(key) {
     const start = parsePeriodKey(key);
-    const opts = { month: 'short', day: 'numeric' };
-    if (start.getFullYear() !== new Date().getFullYear()) opts.year = 'numeric';
-    return start.toLocaleDateString(undefined, opts);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 27); // 28-day inclusive window
+    const now = new Date().getFullYear();
+    const sOpts = { month: 'short', day: 'numeric' };
+    const eOpts = { month: 'short', day: 'numeric' };
+    if (start.getFullYear() !== now) sOpts.year = 'numeric';
+    if (end.getFullYear() !== now) eOpts.year = 'numeric';
+    return `${start.toLocaleDateString(undefined, sOpts)} – ${end.toLocaleDateString(undefined, eOpts)}`;
   }
 
   function fmt(n) {

--- a/app.js
+++ b/app.js
@@ -164,22 +164,45 @@ import { firebaseConfig } from './firebase-config.js';
   }
 
   /**
-   * Render a period as a roughly-4-week range starting from its
-   * paycheck date. The actual gap between paychecks isn't fixed
-   * (varies with weekends/holidays), but 28 days is a reasonable
-   * approximation and keeps every period's label honest regardless
-   * of what the next period's start happens to be.
+   * Days elapsed from a period's start to today (whole calendar days).
+   */
+  function daysSincePeriodStart(key) {
+    const start = parsePeriodKey(key);
+    const now = new Date();
+    const startMs = new Date(start.getFullYear(), start.getMonth(), start.getDate()).getTime();
+    const nowMs = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    return Math.floor((nowMs - startMs) / 86400000);
+  }
+
+  /**
+   * A period is overdue once we're past its 28-day window. Only the active
+   * period can be "overdue" — past periods are already locked in history.
+   */
+  function isPeriodOverdue(key) {
+    return key === data.currentPeriod && daysSincePeriodStart(key) >= 28;
+  }
+
+  /**
+   * Render a period as a roughly-4-week range starting from its paycheck
+   * date. If it's the *active* period and we're past the 28-day window,
+   * flip the end to "present" so the label honestly signals "you're
+   * overdue for a reset."
    */
   function periodLabel(key) {
     const start = parsePeriodKey(key);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 27); // 28-day inclusive window
     const now = new Date().getFullYear();
     const sOpts = { month: 'short', day: 'numeric' };
-    const eOpts = { month: 'short', day: 'numeric' };
     if (start.getFullYear() !== now) sOpts.year = 'numeric';
+    const startStr = start.toLocaleDateString(undefined, sOpts);
+
+    if (isPeriodOverdue(key)) {
+      return `${startStr} – present`;
+    }
+    const end = new Date(start);
+    end.setDate(end.getDate() + 27);
+    const eOpts = { month: 'short', day: 'numeric' };
     if (end.getFullYear() !== now) eOpts.year = 'numeric';
-    return `${start.toLocaleDateString(undefined, sOpts)} – ${end.toLocaleDateString(undefined, eOpts)}`;
+    return `${startStr} – ${end.toLocaleDateString(undefined, eOpts)}`;
   }
 
   function fmt(n) {
@@ -224,10 +247,26 @@ import { firebaseConfig } from './firebase-config.js';
   // ---------- Rendering ----------
   function render() {
     renderHeader();
+    renderOverdueBanner();
     renderDashboard();
     renderChart();
     renderIncome();
     renderCategories();
+  }
+
+  function renderOverdueBanner() {
+    const banner = document.getElementById('overdue-banner');
+    if (!banner) return;
+    // Only nudge on the active period — past periods being "overdue"
+    // is meaningless since they've already been replaced.
+    if (viewingPeriod || !isPeriodOverdue(data.currentPeriod)) {
+      banner.hidden = true;
+      return;
+    }
+    const days = daysSincePeriodStart(data.currentPeriod);
+    const text = document.getElementById('overdue-text');
+    text.textContent = `It's been ${days} days since your last paycheck — time to start a new pay period?`;
+    banner.hidden = false;
   }
 
   function renderChart() {
@@ -1117,9 +1156,13 @@ import { firebaseConfig } from './firebase-config.js';
         render();
       }
     });
-    document.getElementById('reset-month').addEventListener('click', () => {
-      confirmDelete('Start a new pay period?', 'This locks in the current period as history and starts a fresh one today. Categories carry over with $0 spent; anything marked 🔁 Recurring auto-copies in.', startNewPeriod);
-    });
+    const newPeriodPrompt = () => confirmDelete(
+      'Start a new pay period?',
+      'This locks in the current period as history and starts a fresh one today. Categories carry over with $0 spent; anything marked 🔁 Recurring auto-copies in.',
+      startNewPeriod
+    );
+    document.getElementById('reset-month').addEventListener('click', newPeriodPrompt);
+    document.getElementById('overdue-action').addEventListener('click', newPeriodPrompt);
     document.getElementById('unlock-month').addEventListener('click', reactivatePeriod);
     document.getElementById('clear-month').addEventListener('click', () => {
       const label = periodLabel(activePeriod());

--- a/index.html
+++ b/index.html
@@ -82,6 +82,13 @@
   </header>
 
   <main>
+    <!-- Overdue banner (shown when the active period is past its 4-week window) -->
+    <div id="overdue-banner" class="overdue-banner" hidden>
+      <span class="overdue-icon">⏰</span>
+      <span class="overdue-text" id="overdue-text"></span>
+      <button id="overdue-action" class="ghost-btn">Start new period</button>
+    </div>
+
     <!-- Stats Dashboard -->
     <section class="dashboard">
       <div class="stat-card stat-income">

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,7 @@
  * and need fresh tokens).
  */
 
-const CACHE = 'budget-quest-v5';
+const CACHE = 'budget-quest-v6';
 const ASSETS = [
   './',
   './index.html',

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,7 @@
  * and need fresh tokens).
  */
 
-const CACHE = 'budget-quest-v4';
+const CACHE = 'budget-quest-v5';
 const ASSETS = [
   './',
   './index.html',

--- a/styles.css
+++ b/styles.css
@@ -872,6 +872,46 @@ main {
 }
 
 .muted { color: var(--muted); font-size: 13px; }
+
+/* Nudge banner when the active pay period has run past its 4-week window. */
+.overdue-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--warn) 14%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent);
+  margin: 0 0 16px;
+  animation: pop-in 0.35s cubic-bezier(0.34, 1.4, 0.64, 1) backwards;
+}
+.overdue-banner .overdue-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+.overdue-banner .overdue-text {
+  flex: 1;
+  font-size: 13px;
+  color: var(--ink);
+  font-weight: 500;
+}
+.overdue-banner .ghost-btn {
+  padding: 7px 12px;
+  font-size: 12.5px;
+  background: var(--surface);
+  border-color: color-mix(in srgb, var(--warn) 45%, transparent);
+  color: var(--ink);
+  flex-shrink: 0;
+}
+.overdue-banner .ghost-btn:hover {
+  background: color-mix(in srgb, var(--warn) 12%, var(--surface));
+  border-color: color-mix(in srgb, var(--warn) 60%, transparent);
+}
+@media (max-width: 480px) {
+  .overdue-banner { flex-wrap: wrap; }
+  .overdue-banner .overdue-text { flex-basis: calc(100% - 30px); }
+  .overdue-banner .ghost-btn { width: 100%; }
+}
 .label-hint { font-weight: 400; text-transform: none; letter-spacing: 0; color: var(--muted); margin-left: 4px; }
 
 /* Checkbox row inside modals */


### PR DESCRIPTION
## Summary

Two related changes to how pay periods are displayed.

### 1. Fixed 4-week range from start date

The previous "until next period's start" version was misleading for migrated months — e.g. `May 1 – May 31` was a synthetic calendar boundary, not a paycheck-derived end. Switch to a fixed 28-day window from your paycheck date:

- Honest (we know your paycheck date; we approximate the cycle length)
- Consistent (every period looks the same regardless of what's chronologically next)
- Roughly accurate (your actual paydays are spaced ~28–33 days apart)

Examples:
- Paid May 27 → `May 27 – Jun 23`
- Paid Dec 28, 2025 → `Dec 28, 2025 – Jan 24, 2026`

### 2. Overdue handling (label flip + nudge banner)

The fixed-window label was locked at start + 28 days no matter what. If you forgot to start a new period after 28 days, the label would lie — keep showing the original window even though expenses were still flowing into the period.

Two pieces:

**Label flip.** Once the active period crosses 28 days, `periodLabel()` flips the end from a fixed date (`May 27 – Jun 23`) to `May 27 – present`. Past periods always keep their fixed 4-week range (they're locked).

**Nudge banner.** An amber banner appears at the top of the page when the active period is overdue:

> ⏰  It's been 33 days since your last paycheck — time to start a new pay period?  [Start new period]

Clicking the button goes through the same confirm flow as the header **↻ New Period** pill (they share the prompt function so behavior stays in sync). The banner is hidden when viewing a past period and when the active period is within its 28-day window.

Service-worker cache bumped to `v6`.

## Test plan

- [ ] Within 28 days of a period start, header shows fixed range `May 27 – Jun 23`, no banner
- [ ] At day 29+, header shows `May 27 – present`, amber banner appears with day count
- [ ] Tap the banner's "Start new period" → same confirm dialog as the header button → new period rolls forward, banner disappears
- [ ] Navigate to a past period (‹ arrow) → banner stays hidden, past period shows its fixed 4-week range
- [ ] Cross-year periods include the year (`Dec 28, 2025 – Jan 24, 2026`)
- [ ] On phones <480px the banner wraps cleanly and the button goes full-width