### PR TITLE
Drop the overdue nudge banner; keep just the label flip

### DIFF
--- a/app.js
+++ b/app.js
@@ -247,26 +247,10 @@ import { firebaseConfig } from './firebase-config.js';
   // ---------- Rendering ----------
   function render() {
     renderHeader();
-    renderOverdueBanner();
     renderDashboard();
     renderChart();
     renderIncome();
     renderCategories();
-  }
-
-  function renderOverdueBanner() {
-    const banner = document.getElementById('overdue-banner');
-    if (!banner) return;
-    // Only nudge on the active period — past periods being "overdue"
-    // is meaningless since they've already been replaced.
-    if (viewingPeriod || !isPeriodOverdue(data.currentPeriod)) {
-      banner.hidden = true;
-      return;
-    }
-    const days = daysSincePeriodStart(data.currentPeriod);
-    const text = document.getElementById('overdue-text');
-    text.textContent = `It's been ${days} days since your last paycheck — time to start a new pay period?`;
-    banner.hidden = false;
   }
 
   function renderChart() {
@@ -1156,13 +1140,13 @@ import { firebaseConfig } from './firebase-config.js';
         render();
       }
     });
-    const newPeriodPrompt = () => confirmDelete(
-      'Start a new pay period?',
-      'This locks in the current period as history and starts a fresh one today. Categories carry over with $0 spent; anything marked 🔁 Recurring auto-copies in.',
-      startNewPeriod
-    );
-    document.getElementById('reset-month').addEventListener('click', newPeriodPrompt);
-    document.getElementById('overdue-action').addEventListener('click', newPeriodPrompt);
+    document.getElementById('reset-month').addEventListener('click', () => {
+      confirmDelete(
+        'Start a new pay period?',
+        'This locks in the current period as history and starts a fresh one today. Categories carry over with $0 spent; anything marked 🔁 Recurring auto-copies in.',
+        startNewPeriod
+      );
+    });
     document.getElementById('unlock-month').addEventListener('click', reactivatePeriod);
     document.getElementById('clear-month').addEventListener('click', () => {
       const label = periodLabel(activePeriod());

--- a/index.html
+++ b/index.html
@@ -82,13 +82,6 @@
   </header>
 
   <main>
-    <!-- Overdue banner (shown when the active period is past its 4-week window) -->
-    <div id="overdue-banner" class="overdue-banner" hidden>
-      <span class="overdue-icon">⏰</span>
-      <span class="overdue-text" id="overdue-text"></span>
-      <button id="overdue-action" class="ghost-btn">Start new period</button>
-    </div>
-
     <!-- Stats Dashboard -->
     <section class="dashboard">
       <div class="stat-card stat-income">

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,7 @@
  * and need fresh tokens).
  */
 
-const CACHE = 'budget-quest-v6';
+const CACHE = 'budget-quest-v7';
 const ASSETS = [
   './',
   './index.html',

--- a/styles.css
+++ b/styles.css
@@ -872,46 +872,6 @@ main {
 }
 
 .muted { color: var(--muted); font-size: 13px; }
-
-/* Nudge banner when the active pay period has run past its 4-week window. */
-.overdue-banner {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--warn) 14%, var(--surface));
-  border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent);
-  margin: 0 0 16px;
-  animation: pop-in 0.35s cubic-bezier(0.34, 1.4, 0.64, 1) backwards;
-}
-.overdue-banner .overdue-icon {
-  font-size: 18px;
-  line-height: 1;
-}
-.overdue-banner .overdue-text {
-  flex: 1;
-  font-size: 13px;
-  color: var(--ink);
-  font-weight: 500;
-}
-.overdue-banner .ghost-btn {
-  padding: 7px 12px;
-  font-size: 12.5px;
-  background: var(--surface);
-  border-color: color-mix(in srgb, var(--warn) 45%, transparent);
-  color: var(--ink);
-  flex-shrink: 0;
-}
-.overdue-banner .ghost-btn:hover {
-  background: color-mix(in srgb, var(--warn) 12%, var(--surface));
-  border-color: color-mix(in srgb, var(--warn) 60%, transparent);
-}
-@media (max-width: 480px) {
-  .overdue-banner { flex-wrap: wrap; }
-  .overdue-banner .overdue-text { flex-basis: calc(100% - 30px); }
-  .overdue-banner .ghost-btn { width: 100%; }
-}
 .label-hint { font-weight: 400; text-transform: none; letter-spacing: 0; color: var(--muted); margin-left: 4px; }
 
 /* Checkbox row inside modals */


### PR DESCRIPTION
## Summary

Removes the overdue nudge banner that landed in PR #43. The banner duplicated what the header already shows:

- The label flip to `May 27 – present` is enough signal that you're past the window
- The **↻ New Period** button is right there in the top bar, one tap away

Kept:
- `isPeriodOverdue()` and `daysSincePeriodStart()` helpers
- The label flip behavior in `periodLabel()`

Removed:
- The `#overdue-banner` element
- The `.overdue-banner` CSS
- The `renderOverdueBanner()` function and its `render()` call
- The duplicate click handler on `#overdue-action`

Service-worker cache bumped to `v7`.

## Test plan

- [ ] Within 28 days of period start: label shows `May 27 – Jun 23`
- [ ] At day 29+: label flips to `May 27 – present`, no banner
- [ ] Tap **↻ New Period** in the header → confirm dialog → period rolls over as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJgCYn9C2fp18sH4br8GSj)_